### PR TITLE
ci(docker): add missing OCI image labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,21 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          labels: |
+            org.opencontainers.image.title=Pebblify
+            org.opencontainers.image.description=LevelDB to PebbleDB migration tool for Cosmos/CometBFT nodes.
+            org.opencontainers.image.url=https://www.dockermint.io
+            org.opencontainers.image.documentation=https://github.com/Dockermint/Pebblify
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=Dockermint
+            org.opencontainers.image.authors=Dockermint
+            org.opencontainers.image.base.name=alpine:3.22
+
       - name: Build image (no push)
         uses: docker/build-push-action@v6
         with:
@@ -74,3 +89,4 @@ jobs:
             VERSION=${{ github.sha }}
             REVISION=${{ github.sha }}
             CREATED=${{ github.event.head_commit.timestamp }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,15 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
+          labels: |
+            org.opencontainers.image.title=Pebblify
+            org.opencontainers.image.description=LevelDB to PebbleDB migration tool for Cosmos/CometBFT nodes.
+            org.opencontainers.image.url=https://www.dockermint.io
+            org.opencontainers.image.documentation=https://github.com/Dockermint/Pebblify
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=Dockermint
+            org.opencontainers.image.authors=Dockermint
+            org.opencontainers.image.base.name=alpine:3.22
 
       - name: Build & push
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,13 @@ LABEL org.opencontainers.image.title="Pebblify" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.revision="${REVISION}" \
       org.opencontainers.image.source="https://github.com/Dockermint/Pebblify" \
+      org.opencontainers.image.url="https://www.dockermint.io" \
+      org.opencontainers.image.documentation="https://github.com/Dockermint/Pebblify" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.vendor="Dockermint" \
-      org.opencontainers.image.created="${CREATED}"
+      org.opencontainers.image.authors="Dockermint" \
+      org.opencontainers.image.created="${CREATED}" \
+      org.opencontainers.image.base.name="alpine:3.22"
 
 RUN apk add --no-cache ca-certificates tzdata curl \
     && adduser -D -H -u 10000 -s /sbin/nologin appuser


### PR DESCRIPTION
Add url, documentation, authors and base.name labels to the Dockerfile and propagate all OCI labels via docker/metadata-action in both CI and release workflows.