### PR TITLE
ci: run CI on develop branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   push:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read


### PR DESCRIPTION
Add develop to push and pull_request branch triggers so that lint, build, and docker jobs also run for the develop branch.