### PR TITLE
fix(ci): add OCI annotations to multi-arch manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v6
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -87,6 +89,7 @@ jobs:
             CREATED=${{ github.event.head_commit.timestamp }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 
   release:
     name: GitHub Release


### PR DESCRIPTION
GHCR reads the description from manifest-level annotations, not from per-image labels. Set DOCKER_METADATA_ANNOTATIONS_LEVELS to propagate OCI metadata at both manifest and index levels.