### PR TITLE
Chore/v0.4.0 governance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ go.work.sum
 .pebblify-tmp/
 pebblify.lock
 state.json
+
+# Claude memory
+.claude/agent-memory/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Each agent got **exclusive write scope**. No two agents write same files.
 | `docs/specs/`, `docs/ROADMAP.md`                 | `software-architect` | Read-only|
 | `docs/markdown/`, `docs/docusaurus/`, `README`   | `technical-writer` | Read-only  |
 | `.github/`                                       | `devops`           | Read-only  |
-| `Dockerfile*`, `docker-compose*.yml`, `**/*.container`, `**/*.pod`, `**/*.volume`, `**/*.network`, `.dockerignore` | `container-engineer` | Read-only |
+| Dockerfile*, docker-compose*.yml, **/*.container, **/*.pod, **/*.volume, **/*.network, **/*.service, **/*.socket, **/*.timer, systemd/**, .dockerignore | container-engineer | Read-only |
 | Git operations                                   | `sysadmin`         | Forbidden  |
 | Web research                                     | `assistant`        | Forbidden  |
 
@@ -148,6 +148,10 @@ Each agent got **exclusive write scope**. No two agents write same files.
 - **Architecture questions**: `@software-architect` always ask CEO for unspecified requirements, never invent.
 - **Container/Docker work**: `@container-engineer` = sole producer of container artifacts.
 - **Retrocontrol**: `@it-consultant` propose rule tightenings, **NEVER** relax.
+
+### Security
+
+- **Environment templates**: `.env.example`, `systemd/*.env.example` must contain placeholders only. No real secrets, API keys, passwords, or PII. Format: `VAR_NAME=` (empty) or `VAR_NAME={{placeholder}}`. Pre-commit verify no secrets leaked via templates.                                                                      
 
 ### Rules for All Agents
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,68 @@
+# Pebblify Roadmap
+
+Owner: `@software-architect`
+Last updated: 2026-04-18
+
+---
+
+## Release History
+
+| Version | Date       | Theme                                              |
+| :------ | :--------- | :------------------------------------------------- |
+| v0.1.0  | —          | Initial release: LevelDB→PebbleDB conversion CLI  |
+| v0.2.0  | —          | Modular refactor, cmd/pebblify, Docker labels      |
+| v0.3.0  | —          | Health probes, Prometheus metrics, shell completion|
+| v0.3.1  | —          | PebbleDB write-option tuning, CI on develop        |
+| v0.3.2  | —          | Prometheus Help strings, client_golang bump        |
+
+---
+
+## Active Release
+
+### v0.4.0 — Daemon Mode, CI Attestations, Podman
+
+Target: minor bump — no breaking changes to existing CLI surface.
+
+Full plan: [`docs/roadmap/v0.4.0.md`](roadmap/v0.4.0.md)
+
+Platform notes:
+- `pebblify daemon` is Linux-only at runtime. All four build targets (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64) compile, but the daemon subcommand is guarded by a Linux build tag. macOS users run the daemon via Docker or Podman.
+- `install-cli` is cross-platform. `install-systemd-daemon` is Linux-only. There is no `install-launchd-daemon` target.
+- CLAUDE.md scope amendment required before `@container-engineer` can author `systemd/` files. See `docs/roadmap/v0.4.0.md` — "CLAUDE.md Amendment Required".
+
+Feature branches (1 PR = 1 feature = 1 issue):
+
+| Branch                       | Spec                                              | Owner(s)                                |
+| :--------------------------- | :------------------------------------------------ | :-------------------------------------- |
+| `feat/ci-attestations-arm64` | `docs/specs/ci-attestations-arm64.md`             | `@devops`                               |
+| `feat/daemon-mode`           | `docs/specs/daemon-mode.md`                       | `@go-developer`, `@lead-dev`, `@container-engineer` |
+| `feat/podman-support`        | `docs/specs/podman-support.md`                    | `@lead-dev`, `@container-engineer`      |
+| `docs/release-v0.4.0`        | `docs/specs/documentation-refresh.md`             | `@technical-writer`                     |
+
+---
+
+## Backlog (post-v0.4.0)
+
+Items captured for future planning. Not committed to a release.
+
+- Fish shell completion
+- YAML config file support (alternative to TOML)
+- Metrics streaming via OpenTelemetry OTLP
+- Daemon: webhook notify mode (Telegram confirmed for v0.4.0; webhook deferred — Notifier interface ready for drop-in extension)
+- Daemon: GCS and Azure Blob save targets
+- Daemon: bounded concurrency (v0.4.0 uses serial FIFO queue; parallel processing deferred)
+- Windows build target (CGO-free path investigation)
+- `pebblify validate-config` subcommand for daemon config dry-run
+
+---
+
+## Architecture Principles
+
+These govern all releases. Non-negotiable.
+
+1. **Interface-first** — every package boundary is a Go interface. Replace implementations without touching callers.
+2. **Zero CGO** — all build targets compile with `CGO_ENABLED=0`. No C dependencies.
+3. **Additive CLI** — new subcommands never alter existing flag behavior.
+4. **Config versioning** — every config schema carries a `config_version` integer field. Breaking changes increment it.
+5. **Secrets in env only** — `PEBBLIFY_*` env vars for all secrets. Never in config files, never in code.
+6. **Lint-clean** — `golangci-lint run` and `govulncheck ./...` pass before any commit. No `//nolint` suppressions.

--- a/docs/roadmap/v0.4.0.md
+++ b/docs/roadmap/v0.4.0.md
@@ -1,0 +1,255 @@
+# Release Plan — v0.4.0
+
+Owner: `@software-architect`
+Date: 2026-04-18
+Last revised: 2026-04-18 (CEO decisions locked)
+Semver bump: `v0.3.2` → `v0.4.0` (minor — new features, no breaking changes)
+
+---
+
+## CEO Decisions Locked 2026-04-18
+
+The five open questions from the initial draft were answered by the CEO on 2026-04-18 and are locked in all specs. No re-opening without a new CEO confirmation.
+
+| # | Question                          | Decision                                                                                                                              |
+| :- | :-------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| 1 | S3 backend library                | `aws-sdk-go-v2` confirmed. `@lead-dev` imports only `config`, `credentials`, `service/s3` sub-modules. No other service modules.      |
+| 2 | Notify scope                      | Telegram only for v0.4.0. Webhook deferred to backlog. `Notifier` interface designed for drop-in extension without config schema changes. |
+| 3 | Concurrency / queue design        | In-memory FIFO queue, single worker goroutine. 409 only for duplicate URLs (running or queued). Full queue design in daemon-mode.md.   |
+| 4 | systemd unit file owner           | Reassigned to `@container-engineer`. Files: `systemd/pebblify.service`, `systemd/pebblify.env.example`. Requires CLAUDE.md scope amendment (see below). |
+| 5 | Platform support for daemon       | Daemon is Linux-only. macOS users run daemon via Docker or Podman. `install-cli` cross-platform. `install-systemd-daemon` Linux-only. No `install-launchd-daemon`. |
+
+---
+
+## CLAUDE.md Amendment Required
+
+**This amendment must be approved and committed by the CEO before step 5 (GitHub issue creation) can proceed for any work that assigns systemd unit files to `@container-engineer`.**
+
+### Problem
+
+`@container-engineer`'s current write scope in the CLAUDE.md scope matrix covers:
+
+```
+Dockerfile*, docker-compose*.yml, **/*.container, **/*.pod, **/*.volume, **/*.network, .dockerignore
+```
+
+Systemd unit files (`*.service`, `*.socket`, `*.timer`) and the `systemd/` directory are not included. CEO decision #4 assigns `systemd/pebblify.service` and `systemd/pebblify.env.example` to `@container-engineer`.
+
+### Proposed Scope-Matrix Line Addition
+
+Replace the existing `@container-engineer` row in the CLAUDE.md scope matrix with:
+
+```
+| `Dockerfile*`, `docker-compose*.yml`, `**/*.container`, `**/*.pod`, `**/*.volume`, `**/*.network`, `.dockerignore`, `systemd/**`, `**/*.service`, `**/*.socket`, `**/*.timer` | `container-engineer` | Read-only |
+```
+
+### Process
+
+Per CLAUDE.md Rule Integrity:
+1. This proposal is forwarded to `@it-consultant` for evaluation.
+2. `@it-consultant` reports whether the addition is acceptable (can only tighten, not relax — this is an extension, not a relaxation).
+3. CEO manually edits CLAUDE.md and commits.
+4. New scope takes effect.
+
+Until this amendment is committed, `@container-engineer` must not author or commit `systemd/` files, and `@sysadmin` must refuse to stage them.
+
+---
+
+## Goals
+
+1. Extend CI/release pipeline with darwin targets and SLSA attestations for all binaries and Docker images.
+2. Introduce daemon mode: a long-running HTTP service (Linux-only) that receives snapshot URLs, converts them, and pushes results to configurable save targets.
+3. Add Podman Quadlet install support for rootless daemon deployment.
+4. Refresh documentation to cover all new surface, with platform-split install guides.
+
+---
+
+## Scope
+
+### In scope
+
+- GitHub Actions: darwin/amd64 + darwin/arm64 binaries, artifact attestations (SLSA provenance + SBOM), multi-arch Docker publish.
+- `pebblify daemon` subcommand backed by `internal/daemon/` package tree. **Linux-only runtime** (build-tag guarded).
+- Daemon config schema (TOML, config_version = 0), `.env` variable set.
+- Daemon subsystems: HTTP API, Telemetry (Prometheus), Health (`/healthz` + `/readyz`), Notifier (Telegram only), Store (local, SCP, S3), Repack (lz4/zstd/gzip/none).
+- In-memory FIFO job queue with single worker goroutine; 409 dedup by canonicalized URL.
+- Makefile: `install-cli` (cross-platform), `install-systemd-daemon` (Linux-only) targets replacing `install`.
+- `systemd/pebblify.service` and `systemd/pebblify.env.example` (authored by `@container-engineer`, pending scope amendment).
+- `docker-compose.daemon.yml` reference layout (authored by `@container-engineer`).
+- Podman Quadlet `.container` file + `~/.pebblify/` setup.
+- Documentation refresh across README and docs site, with platform-split install sections.
+
+### Out of scope
+
+- Fish shell completion.
+- Webhook or non-Telegram notification modes (deferred to backlog).
+- GCS / Azure Blob store backends.
+- Daemon conversion resume (checkpoint is CLI-only by design).
+- Bounded concurrency / parallel daemon jobs (deferred to backlog).
+- `install-launchd-daemon` or any macOS-native daemon install target (removed from scope; macOS users use Docker/Podman).
+
+---
+
+## Dep-Risk Callouts for @lead-dev
+
+The following new dependencies are required. `@lead-dev` evaluates each for security, licence, and maintenance health via `govulncheck` before accepting.
+
+| Dependency                                     | Purpose                         | Risk level | Notes                                                                     |
+| :--------------------------------------------- | :------------------------------ | :--------- | :------------------------------------------------------------------------ |
+| `github.com/BurntSushi/toml`                   | TOML config parsing             | Low        | Stable, widely used; check for v1.x licence                               |
+| `github.com/aws/aws-sdk-go-v2/config`          | AWS config loading              | Medium     | CEO-confirmed; import only this sub-module + credentials + service/s3     |
+| `github.com/aws/aws-sdk-go-v2/credentials`     | AWS credential providers        | Medium     | See above                                                                  |
+| `github.com/aws/aws-sdk-go-v2/service/s3`      | S3 upload via SigV4             | Medium     | See above; no other aws service modules permitted                          |
+| `github.com/go-telegram-bot-api/telegram-bot-api/v5` | Telegram notify          | Low        | Evaluate last commit date + CVE history; fallback is raw net/http         |
+| `golang.org/x/crypto`                          | SCP/SSH transport               | Low        | Already indirect; promote to direct                                        |
+
+Fallback for `go-telegram-bot-api`: raw Telegram Bot HTTP API with `net/http` + `encoding/json`. Zero additional deps.
+
+---
+
+## Ordered Commit Plan
+
+Each feature branch merges to `develop`, not directly to `main`. The merge sequence below respects inter-feature dependencies (CI/attestations must land before daemon because daemon release binaries need the new matrix).
+
+### Branch 1 — `feat/ci-attestations-arm64`
+
+Merges independently. No code dependency on other branches.
+
+```
+Step 5:  @sysadmin  — create GitHub issue (template: feature)
+Step 6:  @lead-dev  — no new deps; verify existing action versions
+Step 7:  @devops    — update .github/workflows/release.yml:
+                       add darwin/amd64 + darwin/arm64 matrix entries
+                       add attestation jobs (binary + Docker)
+                       add permissions block: id-token:write, attestations:write
+Step 8:  @qa        — CI green on test push; verify gh attestation verify output
+Step 10: @reviewer  — APPROVE or BLOCK
+Step 11: @sysadmin  — GPG commit, PR
+```
+
+### Branch 2 — `feat/daemon-mode`
+
+Largest branch. **Blocked** on CLAUDE.md scope amendment for systemd files (see above). Issue creation (step 5) must wait until amendment is committed.
+
+Ordered commits within the branch:
+
+```
+Commit 1: internal/daemon/config  — TOML schema loader, env overlay, validation
+Commit 2: internal/daemon/queue   — in-memory FIFO queue, dedup, shutdown gate
+Commit 3: internal/daemon/api     — HTTP server, auth middleware, job handler (enqueue path)
+Commit 4: internal/daemon/notify  — Notifier interface + Telegram + Noop implementations
+Commit 5: internal/daemon/repack  — Repacker interface + lz4/zstd/gzip/none impls
+Commit 6: internal/daemon/store   — Storer interface + local/SCP/S3 impls
+Commit 7: internal/daemon         — Orchestrator: wiring all sub-packages + worker goroutine
+Commit 8: cmd/pebblify/main.go    — add `daemon` case (linux build tag); non-linux stub
+Step 5:  @sysadmin  — create GitHub issue (after CLAUDE.md amendment committed)
+Step 6:  @lead-dev  — add TOML, aws-sdk-go-v2 (3 sub-modules only), telegram lib, x/crypto
+Step 7–10: iterate per CLAUDE.md workflow loop
+Step 11: @sysadmin  — GPG commit, PR
+```
+
+Agent deliverables within this branch:
+- `@go-developer`: `internal/daemon/**/*.go`, `cmd/pebblify/main.go`
+- `@lead-dev`: `go.mod`, `go.sum`, `Makefile` (install-cli + install-systemd-daemon targets)
+- `@container-engineer`: `docker-compose.daemon.yml`, `systemd/pebblify.service`, `systemd/pebblify.env.example` (pending scope amendment)
+
+### Branch 3 — `feat/podman-support`
+
+Depends on daemon config paths being finalized in branch 2. Merge branch 2 first.
+
+```
+Step 5:  @sysadmin         — create GitHub issue
+Step 6:  @lead-dev         — no new Go deps; Makefile target additions
+Step 7a: @lead-dev         — Makefile: add install-podman target
+Step 7b: @container-engineer — author deploy/quadlet/pebblify.container
+Step 8–10: iterate
+Step 11: @sysadmin         — GPG commit, PR
+```
+
+### Branch 4 — `docs/release-v0.4.0`
+
+Merges after branches 1–3 are on `develop`.
+
+```
+Step 14: @technical-writer — README daemon section, docs/markdown/, docs/docusaurus/
+                             platform-split install docs (install-cli cross-platform,
+                             install-systemd-daemon Linux-only,
+                             install-podman Linux/macOS-via-Podman-Desktop)
+Step 11: @sysadmin         — GPG commit, PR
+```
+
+---
+
+## Merge Strategy
+
+- All branches target `develop`.
+- `develop` → `main` via single release PR after all 4 feature PRs are merged + CI green.
+- Tag `v0.4.0` on `main` after release PR merges. Tag triggers `.github/workflows/release.yml`.
+- No force-push to `main` or `develop` at any time.
+
+---
+
+## Release-Notes Draft
+
+```
+## v0.4.0 — 2026-??-??
+
+### Added
+
+- **Daemon mode** (`pebblify daemon`, Linux-only): long-running service that
+  accepts snapshot URLs via HTTP API, converts LevelDB archives to PebbleDB,
+  and pushes results to local directory, SCP, or S3 targets. macOS users run
+  the daemon via Docker or Podman.
+- **In-memory job queue**: FIFO queue with single worker goroutine; 409 Conflict
+  on duplicate URL (running or queued); clean drain on SIGTERM.
+- **Telegram notifications**: opt-in notify on job completion or failure.
+- **Daemon Prometheus metrics**: jobs_in_progress, job_success_total,
+  job_failure_total, queue_depth, bytes_downloaded_total, bytes_uploaded_total,
+  conversion_duration_seconds.
+- **Daemon health endpoints**: /healthz (liveness) and /readyz (readiness) on a
+  dedicated port; /readyz returns 503 while any job is running or queued.
+- **TOML config file**: `config.toml` with versioned schema (config_version = 0)
+  covers API, notify, telemetry, health, conversion, and save targets.
+- **Compression support**: repack converted archives as lz4, zstd, gzip, or none.
+- **darwin/amd64 and darwin/arm64 release binaries**: all four mandatory platforms
+  now included in every GitHub Release.
+- **SLSA provenance attestations**: release binaries and Docker images are attested
+  via `actions/attest-build-provenance` and `actions/attest-sbom`. Verifiable
+  with `gh attestation verify`.
+- **Makefile targets**: `install-cli` (user-scope, cross-platform) and
+  `install-systemd-daemon` (root-scope, Linux-only, with systemd unit +
+  /etc/pebblify/ scaffold).
+- **Podman Quadlet support**: `make install-podman` installs a rootless Quadlet
+  `.container` file and default config under `~/.pebblify/`.
+- **systemd unit files**: `systemd/pebblify.service` and
+  `systemd/pebblify.env.example` checked into the repo (authored by
+  @container-engineer).
+
+### Changed
+
+- Makefile `install` target replaced by `install-cli` and `install-systemd-daemon`.
+  Existing `build`, `build-linux-*`, `clean`, `info` targets are unchanged.
+
+### Fixed
+
+- Nothing in this release (all changes are additive).
+
+### Security
+
+- Daemon API token (`PEBBLIFY_BASIC_AUTH_TOKEN`) is read exclusively from env;
+  never written to config files or logs.
+- S3 secret key (`PEBBLIFY_S3_SECRET_KEY`) same isolation guarantee.
+- SCP credentials (`PEBBLIFY_SCP_KEY_PATH`, `PEBBLIFY_SCP_PASSWORD`) same.
+- Telegram bot token (`PEBBLIFY_TELEGRAM_BOT_TOKEN`) same.
+- SLSA Level 2 provenance for all release artifacts.
+- aws-sdk-go-v2 surface minimized: only config, credentials, service/s3 imported.
+```
+
+---
+
+## Rollback Plan
+
+1. **Binaries**: GitHub Releases are immutable once published. If a critical regression is found post-release, publish `v0.4.1` with the fix. Do not delete or re-publish `v0.4.0` artifacts.
+2. **Docker images**: `ghcr.io/dockermint/pebblify:v0.3.2` remains available. Operators can pin to the previous tag. Do not overwrite or delete the `v0.3.2` tag on GHCR.
+3. **Daemon config**: `config_version = 0` is the initial schema. Future breaking changes increment the version; the loader rejects configs with an unknown version and emits a clear migration message.
+4. **Makefile**: the old `install` target is replaced, not augmented. If regression is found, `install-cli` is the functional equivalent and can be aliased in a hotfix.

--- a/docs/specs/ci-attestations-arm64.md
+++ b/docs/specs/ci-attestations-arm64.md
@@ -1,0 +1,184 @@
+# Spec: CI Attestations + darwin Targets
+
+Owner: `@software-architect`
+Date: 2026-04-18
+Feature branch: `feat/ci-attestations-arm64`
+Implementation owner: `@devops`
+
+---
+
+## Objective
+
+1. Add darwin/amd64 and darwin/arm64 to the release binary matrix (currently linux-only).
+2. Publish SLSA provenance and SBOM attestations for every release binary and the multi-arch Docker image.
+3. Enable `gh attestation verify` verification by consumers.
+
+Reference: https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations
+
+---
+
+## Files to Touch
+
+All files are owned by `@devops`. No other files change.
+
+| File                                | Change type |
+| :---------------------------------- | :---------- |
+| `.github/workflows/release.yml`     | Modify      |
+| `.github/workflows/ci.yml`          | Modify      |
+
+---
+
+## CI Workflow Changes (`ci.yml`)
+
+### Build matrix expansion
+
+Current matrix:
+```yaml
+strategy:
+  matrix:
+    goos: [linux]
+    goarch: [amd64, arm64]
+```
+
+New matrix:
+```yaml
+strategy:
+  matrix:
+    include:
+      - goos: linux
+        goarch: amd64
+        runner: ubuntu-latest
+      - goos: linux
+        goarch: arm64
+        runner: ubuntu-latest
+      - goos: darwin
+        goarch: amd64
+        runner: ubuntu-latest
+      - goos: darwin
+        goarch: arm64
+        runner: ubuntu-latest
+```
+
+Cross-compilation works from ubuntu-latest because `CGO_ENABLED=0` requires no host toolchain for the target. No macOS runner is needed for the build job.
+
+### Docker build job
+
+The CI `docker` job currently builds `linux/amd64` only (no push). Extend to `linux/amd64,linux/arm64` using `docker/build-push-action` with `push: false`. No permission changes needed for CI (no push, no attestation in CI).
+
+---
+
+## Release Workflow Changes (`release.yml`)
+
+### Required permissions block
+
+Top-level permissions must include:
+
+```yaml
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+```
+
+The existing `contents: write` and `packages: write` are present. Add `id-token: write` and `attestations: write`.
+
+### Binary build matrix
+
+Mirror the CI matrix expansion above. All four targets compile from `ubuntu-latest` with `CGO_ENABLED=0`.
+
+Output filenames follow the existing convention:
+`pebblify-<goos>-<goarch>`
+
+### Binary attestation job
+
+Add a job `attest-binaries` that runs after `build`:
+
+```
+Depends on: build
+Runner: ubuntu-latest
+Steps:
+  1. actions/checkout@v4 (or latest pinned)
+  2. actions/download-artifact@v4 — download all four pebblify-* artifacts
+  3. actions/attest-build-provenance@v2
+       subject-path: 'pebblify-*'
+  4. actions/attest-sbom@v1 (if available as stable)
+       subject-path: 'pebblify-*'
+       sbom-format: spdx-json   (or cyclonedx-json — @devops chooses)
+```
+
+Note: verify exact action versions from https://github.com/actions/attest-build-provenance/releases and https://github.com/actions/attest-sbom/releases at implementation time. `@assistant` can look these up.
+
+### Docker publish + attestation job
+
+The existing `docker` job builds multi-arch and pushes to GHCR. Extend with attestation:
+
+```
+After docker push completes:
+  - actions/attest-build-provenance@v2
+      subject-name: ghcr.io/${{ github.repository }}
+      subject-digest: ${{ steps.push.outputs.digest }}
+      push-to-registry: true
+```
+
+The `docker/build-push-action` must be configured to output the image digest:
+
+```yaml
+- name: Build and push
+  id: push
+  uses: docker/build-push-action@v7
+  with:
+    push: true
+    platforms: linux/amd64,linux/arm64
+    ...
+```
+
+`steps.push.outputs.digest` provides the required subject-digest value.
+
+### GitHub Release upload
+
+The existing release workflow uses `actions/upload-artifact` + a release job. Ensure all four binaries are uploaded to the GitHub Release asset list. If the workflow currently uses `softprops/action-gh-release` or equivalent, update the `files` glob to include `pebblify-darwin-*`.
+
+---
+
+## Verification Steps
+
+Consumers can verify an artifact with:
+
+```bash
+gh attestation verify pebblify-linux-amd64 \
+  --repo Dockermint/Pebblify
+
+gh attestation verify pebblify-darwin-arm64 \
+  --repo Dockermint/Pebblify
+```
+
+For Docker:
+
+```bash
+gh attestation verify \
+  oci://ghcr.io/dockermint/pebblify:v0.4.0 \
+  --repo Dockermint/Pebblify
+```
+
+`@devops` must include these commands in the release workflow README section and in the release notes.
+
+---
+
+## Invariants
+
+- `CGO_ENABLED=0` for all four targets. No cgo, no host toolchain dependency.
+- Attestation jobs run only on tag pushes (`on: push: tags: ["v*"]`). Never on PR or branch push.
+- Permissions are scoped to the jobs that need them, not promoted globally beyond what is listed.
+- No secrets are embedded in workflow files. Docker login uses `${{ secrets.GITHUB_TOKEN }}` only.
+
+---
+
+## Hand-off
+
+| Agent      | Scope files                                        | Action                         |
+| :--------- | :------------------------------------------------- | :----------------------------- |
+| `@devops`  | `.github/workflows/release.yml`, `.github/workflows/ci.yml` | Implement changes above |
+| `@reviewer`| read-only                                          | Audit compliance, APPROVE/BLOCK|
+| `@qa`      | no test files; CI validation is the test           | Verify CI green on test tag    |
+| `@sysadmin`| git operations                                     | Branch, commit, PR             |

--- a/docs/specs/daemon-mode.md
+++ b/docs/specs/daemon-mode.md
@@ -1,0 +1,615 @@
+# Spec: Daemon Mode
+
+Owner: `@software-architect`
+Date: 2026-04-18
+Last revised: 2026-04-18 (CEO decisions locked — see section "CEO Decisions Locked 2026-04-18")
+Feature branch: `feat/daemon-mode`
+Implementation owner: `@go-developer`, `@lead-dev`, `@container-engineer`
+
+---
+
+## CEO Decisions Locked 2026-04-18
+
+The five open questions from the initial draft were answered by the CEO on 2026-04-18. All decisions below are locked and must not be re-opened without a new CEO confirmation.
+
+1. **S3 backend**: `aws-sdk-go-v2` confirmed. `@lead-dev` must import only the required sub-modules (at minimum: `github.com/aws/aws-sdk-go-v2/config`, `github.com/aws/aws-sdk-go-v2/credentials`, `github.com/aws/aws-sdk-go-v2/service/s3`). No other aws-sdk-go-v2 service modules may be added without explicit CEO approval. The fallback (hand-rolled SigV4) is removed from scope.
+
+2. **Notify scope**: Telegram only for v0.4.0. Webhook is deferred to backlog. The `Notifier` interface (see below) is designed for drop-in extension; adding a webhook or other backend in a future release requires only a new implementation file and a config enum value, with no changes to the orchestrator or config schema.
+
+3. **Concurrency model**: In-memory FIFO queue with a single worker goroutine. Full design in the "Job Queue" section below.
+
+4. **systemd unit ownership**: Reassigned to `@container-engineer`. See "systemd Unit Ownership" section and the CLAUDE.md scope amendment flag.
+
+5. **Platform**: Daemon is Linux-only. macOS users run the daemon via Docker or Podman. The `install-cli` target remains cross-platform (all four build targets). `install-systemd-daemon` is Linux-only. There is no `install-launchd-daemon` target in v0.4.0 or any planned release.
+
+---
+
+## Overview
+
+`pebblify daemon` is a long-running HTTP service. It accepts snapshot archive URLs via a REST API, downloads and converts them from LevelDB to PebbleDB format, repacks the output with the configured compression codec, and pushes the result to one or more save targets (local directory, SCP, S3). All configuration is file- and env-driven; the daemon subcommand accepts no positional arguments or conversion flags.
+
+Existing subcommands (`level-to-pebble`, `recover`, `verify`, `completion`) are unchanged.
+
+**Platform constraint**: the `daemon` subcommand is Linux-only. The binary compiles on all four mandatory targets, but `pebblify daemon` at runtime requires Linux (systemd, `/proc`, inotify assumptions in the job pipeline). macOS users must run the daemon inside a Docker or Podman container. A build-tag guard (`//go:build linux`) is placed on `daemon.go`; the `cmd/pebblify/main.go` switch case for `"daemon"` is also guarded by the same build tag. Attempting to run the binary built for darwin with the `daemon` subcommand prints `pebblify daemon is not supported on this platform; use Docker or Podman` and exits 1.
+
+---
+
+## Package Layout
+
+```
+internal/daemon/
+  config/
+    config.go        -- TOML loader, env overlay, validation, Config struct
+  api/
+    server.go        -- HTTP server construction, route wiring
+    middleware.go    -- auth middleware (basic_auth / unsecure)
+    handler.go       -- POST /job handler, request validation, queue submission
+    types.go         -- request/response types
+  notify/
+    notifier.go      -- Notifier interface
+    telegram.go      -- Telegram implementation
+    noop.go          -- no-op implementation (notify disabled)
+  queue/
+    queue.go         -- in-memory FIFO queue, dedup logic, shutdown gate
+  repack/
+    repacker.go      -- Repacker interface
+    lz4.go           -- lz4 implementation
+    zstd.go          -- zstd implementation
+    gzip.go          -- gzip implementation
+    none.go          -- passthrough (no compression) implementation
+  store/
+    storer.go        -- Storer interface
+    local.go         -- local filesystem implementation
+    scp.go           -- SCP/SSH implementation
+    s3.go            -- S3 implementation (aws-sdk-go-v2)
+  orchestrator.go    -- wires config + all sub-packages, runs job pipeline
+  daemon.go          -- Run(cfg) entry point called from cmd/pebblify (linux build tag)
+```
+
+Sub-packages are independently testable. The orchestrator depends on interfaces, not concrete types.
+
+---
+
+## Interfaces
+
+### Notifier
+
+```
+type Notifier interface {
+    Notify(ctx context.Context, msg string) error
+}
+```
+
+Implementations: `TelegramNotifier`, `NoopNotifier`.
+
+**Extension path**: to add a new backend (webhook, Slack, PagerDuty) in a future release:
+1. Create a new file in `internal/daemon/notify/` implementing `Notifier`.
+2. Add a new enum value to `config.notify.mode`.
+3. Wire the new implementation in the orchestrator's factory function.
+No other files change. The `Notifier` interface contract is intentionally minimal (`Notify(ctx, msg) error`) so all backends fit without interface widening.
+
+### Repacker
+
+```
+type Repacker interface {
+    // Pack reads from src archive path, writes repacked archive to dst path.
+    // nonDBFiles must be preserved from the original archive unchanged.
+    Pack(ctx context.Context, src, dst string) error
+    // Extension returns the file extension this repacker produces, e.g. ".tar.lz4".
+    Extension() string
+}
+```
+
+Implementations: `LZ4Repacker`, `ZstdRepacker`, `GzipRepacker`, `NoneRepacker`.
+
+### Storer
+
+```
+type Storer interface {
+    // Store uploads the file at localPath to the configured target.
+    // Returns the remote path/URL for logging.
+    Store(ctx context.Context, localPath, fileName string) (string, error)
+}
+```
+
+Implementations: `LocalStorer`, `SCPStorer`, `S3Storer`.
+
+Multiple Storers may be active simultaneously. The orchestrator iterates enabled stores sequentially. Partial store failures are non-fatal (logged + notified) unless all stores fail, which is treated as a fatal job error.
+
+---
+
+## Configuration
+
+### File
+
+Default path: `./config.toml`. Overridden by `PEBBLIFY_CONFIG_PATH` env var.
+
+```toml
+[general]
+config_version = 0
+
+[api]
+enable = false
+host = "127.0.0.1"
+port = 2324
+authentification_mode = "basic_auth"  # basic_auth | unsecure
+
+[notify]
+enable = false
+mode = "telegram"                     # telegram (only valid value in v0.4.0)
+channel_id = "..."
+
+[telemetry]
+enable = true
+mode = "prometheus"
+host = "127.0.0.1"
+port = 2323
+
+[health]
+enable = true
+host = "127.0.0.1"
+port = 2325
+
+[convertion]
+temporary_directory = "/tmp"
+delete_source_snapshot = true
+
+[save]
+compression = "lz4"  # none | lz4 | zstd | gzip
+
+[save.local]
+enable = true
+local_save_directory = "~/.snapshots"
+
+[save.scp]
+enable = false
+authentification_mode = "key"  # key | password | none
+host = ""
+port = 0
+username = ""
+
+[save.s3]
+enable = false
+bucket_name = ""
+s3_access_key = ""
+save_path = ""
+```
+
+Schema version: `config_version = 0`. The loader rejects configs where `config_version` is absent or exceeds the supported maximum, with a clear error message directing the user to migrate.
+
+Field notes:
+- `api.authentification_mode = "unsecure"` emits a WARN-level log line at startup: `daemon API is running without authentication; set authentification_mode to basic_auth for production use`.
+- `save.local.local_save_directory` supports `~` prefix; the loader expands it via `os.UserHomeDir()`.
+- `save.s3.save_path` is the key prefix; the final S3 key is `/<bucket_name>/<save_path>/<filename>`.
+- `notify.mode` accepts only `"telegram"` in v0.4.0. Any other value is a fatal startup error. The enum is validated at config load time so future modes can be added without changing the loader signature.
+
+### Environment Variables
+
+```
+PEBBLIFY_LOG_LEVEL=info            # trace | debug | info | warn | error
+PEBBLIFY_CONFIG_PATH=              # overrides default ./config.toml
+PEBBLIFY_BASIC_AUTH_TOKEN=         # required when authentification_mode = basic_auth
+PEBBLIFY_TELEGRAM_BOT_TOKEN=       # required when notify.mode = telegram
+PEBBLIFY_SCP_KEY_PATH=             # path to private key; required when scp.authentification_mode = key
+PEBBLIFY_SCP_PASSWORD=             # required when scp.authentification_mode = password
+PEBBLIFY_S3_SECRET_KEY=            # required when save.s3.enable = true
+```
+
+All secret env vars are read at startup. Missing required secrets for an enabled subsystem are a fatal startup error (logged + exit 1 before any listener opens).
+
+---
+
+## Job Queue
+
+### Design
+
+The daemon maintains an in-memory FIFO queue and a single worker goroutine that consumes it. Rationale: PebbleDB and LevelDB are I/O-heavy; parallelizing multiple conversions on the same host causes disk bandwidth contention without a meaningful throughput gain, and complicates cleanup on failure. Serial processing is the correct default; bounded concurrency is a post-v0.4.0 backlog item.
+
+**Queue persistence**: the queue is in-memory only. If the daemon crashes or is stopped, all queued (not yet started) jobs are lost. This is intentional and documented. The operator must resubmit jobs after a restart. The `GET /v1/status` endpoint reflects the current queue depth so operators can verify queue state before stopping the daemon.
+
+### Queue Mechanics
+
+- Data structure: unbounded channel (`chan Job`) used as a FIFO queue. Channel is created with a configurable buffer (default 64); if the buffer fills, new enqueue requests return 503 (not 409 — 409 is reserved for duplicate URLs).
+- Single worker goroutine: started at daemon startup, runs until the shutdown channel is closed.
+- Dedup key: canonicalized snapshot URL. Canonicalization normalizes scheme (lowercased), host (lowercased), path (cleaned via `path.Clean`), and query parameters (sorted by key, then by value). Fragment is discarded. Two URLs that canonicalize to the same string are considered duplicates.
+- Dedup scope: a URL is a duplicate if it is currently running OR currently in the queue. Completed or failed jobs are not tracked for dedup purposes; the same URL may be submitted again after the job finishes.
+
+### Enqueue Rules
+
+| Condition                                                  | HTTP Response                              |
+| :--------------------------------------------------------- | :----------------------------------------- |
+| URL canonicalizes to a running or queued job               | 409 Conflict `{"error":"duplicate job: url already running or queued"}` |
+| Queue buffer full (64 pending jobs)                        | 503 Service Unavailable `{"error":"queue full"}` |
+| Daemon is shutting down (SIGTERM received)                 | 503 Service Unavailable `{"error":"daemon shutting down"}` |
+| Disk space check fails                                     | 507 Insufficient Storage                   |
+| URL validation fails                                       | 400 Bad Request                            |
+| All checks pass                                            | 202 Accepted `{"job_id":"<uuid>","status":"queued"}` |
+
+### Shutdown Sequence (SIGTERM)
+
+1. Signal handler receives SIGTERM.
+2. Daemon sets a shutdown flag; the enqueue path returns 503 for all new requests.
+3. The HTTP API listener stops accepting new connections (graceful shutdown with a 30-second timeout).
+4. The worker goroutine finishes the job currently in progress (no mid-job interruption). All cleanup steps (temp directory removal, notification) run to completion.
+5. Jobs remaining in the queue that have not started are dropped. A WARN-level log entry is emitted for each dropped job, listing its URL.
+6. Daemon exits 0 after the current job completes and all listeners have shut down.
+
+If the current job does not complete within 5 minutes of SIGTERM, the daemon forces exit 1 and logs the timeout. This prevents indefinite hang on a stalled download.
+
+### State Exposed via API and Prometheus
+
+`GET /v1/status` returns `queue_depth` (number of jobs waiting, not counting the running job) and `current_job` (null if idle).
+
+Prometheus gauge `pebblify_daemon_queue_depth` mirrors `queue_depth` in real time.
+
+`/readyz` returns 503 whenever `queue_depth > 0` or a job is running (daemon is busy). Returns 200 only when queue is empty and no job is running.
+
+---
+
+## API
+
+### Listener
+
+Bound to `api.host:api.port`. Enabled only when `api.enable = true`.
+
+HTTP/1.1, no TLS (operators terminate TLS at a reverse proxy). Future versions may add TLS config.
+
+### Authentication
+
+- `basic_auth`: HTTP Basic Auth. Username is ignored. Password is compared to `PEBBLIFY_BASIC_AUTH_TOKEN` using `subtle.ConstantTimeCompare`. Request with invalid token → 401 Unauthorized.
+- `unsecure`: no auth. Warn at startup (see above).
+
+### Routes
+
+```
+POST /v1/job      Submit a conversion job (enqueues; returns 202 immediately)
+GET  /v1/status   Return daemon state, queue depth, and current job info (if any)
+```
+
+#### POST /v1/job
+
+Request body (JSON):
+
+```json
+{
+  "snapshot_url": "https://example.com/snapshot.tar.lz4"
+}
+```
+
+Validation:
+- `snapshot_url` must be a valid URL (scheme http or https).
+- Archive format is inferred from the URL file extension. Supported: `.tar`, `.tar.gz`, `.tar.lz4`, `.tar.zst`, `.zip`. Rejection if extension is unrecognized.
+- Daemon checks free disk space in `convertion.temporary_directory` before accepting the job. Minimum required: estimated archive size * 4 (download + extract + convert + repack). If insufficient, return 507 Insufficient Storage.
+- Dedup check: if the canonicalized URL matches a running or queued job, return 409 Conflict.
+- If daemon is shutting down, return 503.
+
+Response (202 Accepted):
+
+```json
+{
+  "job_id": "<uuid>",
+  "status": "queued"
+}
+```
+
+Response (4xx/5xx):
+
+```json
+{
+  "error": "<message>"
+}
+```
+
+#### GET /v1/status
+
+Response (200 OK):
+
+```json
+{
+  "daemon_version": "0.4.0",
+  "state": "idle",        // idle | converting | error
+  "queue_depth": 0,       // number of jobs waiting (not counting running job)
+  "current_job": null     // null when idle, or job object
+}
+```
+
+Job object:
+
+```json
+{
+  "job_id": "<uuid>",
+  "snapshot_url": "...",
+  "phase": "downloading",  // downloading | extracting | converting | verifying | repacking | storing | notifying
+  "started_at": "<rfc3339>",
+  "elapsed_seconds": 42
+}
+```
+
+---
+
+## Job Pipeline (Orchestrator)
+
+The orchestrator processes one job at a time via the single worker goroutine. Jobs are accepted into the queue immediately (202 response) and processed serially.
+
+```
+Step 1: Dequeue job from FIFO queue (worker goroutine blocks until job available)
+Step 2: Validate free disk space in convertion.temporary_directory
+Step 3: Download archive to convertion.temporary_directory/<job_id>/download/<filename>
+Step 4: Extract archive; detect all LevelDB directories within the extracted tree
+Step 5: For each LevelDB directory: call internal/migration.RunLevelToPebble
+        - Uses internal migration + verify packages; reuses existing RunConfig interface
+        - No crash recovery in daemon mode (stateless per job)
+        - If convertion.delete_source_snapshot = true → remove source LevelDB dir after conversion
+Step 6: Run internal/verify.Run on each converted DB (full verification; no sampling skip in daemon)
+Step 7: Repack entire output directory (converted PebbleDB dirs + non-DB files from original archive)
+        into convertion.temporary_directory/<job_id>/output/<original_name>_pebbledb_<unix_ts>.<ext>
+Step 8: Upload output file to each enabled Storer (local, scp, s3) sequentially
+Step 9: Delete convertion.temporary_directory/<job_id>/ (both download and output)
+Step 10: Notify via Notifier (success or failure message) if notify.enable = true
+```
+
+Output filename pattern: `<original_name>_pebbledb_<unix_timestamp>.<extension>`
+- `<original_name>`: filename of the input archive without extension.
+- `<unix_timestamp>`: Unix timestamp (seconds) at job start.
+- `<extension>`: determined by the Repacker (e.g. `tar.lz4`, `tar.zst`, `tar.gz`, `tar`).
+
+### Error Handling
+
+Non-fatal error (single Storer failure, notification failure):
+- Log at WARN level to stderr.
+- Attempt remaining Storers.
+- Notify failure (if notify enabled).
+- Mark job failed.
+- Worker goroutine loops back to dequeue next job.
+- Do NOT exit.
+
+Fatal error (download failure, extraction failure, conversion failure, all Storers fail):
+- Notify failure (if notify enabled).
+- Log at ERROR level to stderr.
+- Cleanup `convertion.temporary_directory/<job_id>/` completely.
+- Mark job failed.
+- Worker goroutine loops back to dequeue next job.
+- Daemon remains running; fatal error does NOT exit the daemon.
+
+Exit 1 triggers: missing required env var, config parse failure, config_version mismatch, port bind failure on startup.
+
+---
+
+## Telemetry (Prometheus)
+
+Listener bound to `telemetry.host:telemetry.port`. Enabled only when `telemetry.enable = true`.
+
+Route: `GET /metrics` (delegated to existing `internal/prom` handler; add daemon-specific collectors alongside existing ones).
+
+New Prometheus metrics (all namespaced `pebblify_daemon_`):
+
+| Metric                                      | Type      | Labels         | Description                                    |
+| :------------------------------------------ | :-------- | :------------- | :--------------------------------------------- |
+| `pebblify_daemon_jobs_in_progress`          | Gauge     | —              | 0 or 1; jobs run serially                      |
+| `pebblify_daemon_job_success_total`         | Counter   | —              | Total successful jobs                          |
+| `pebblify_daemon_job_failure_total`         | Counter   | phase          | Failures by pipeline phase                     |
+| `pebblify_daemon_queue_depth`               | Gauge     | —              | Pending jobs waiting in FIFO queue             |
+| `pebblify_daemon_bytes_downloaded_total`    | Counter   | —              | Bytes downloaded from snapshot URL             |
+| `pebblify_daemon_bytes_uploaded_total`      | Counter   | target         | Bytes uploaded per store target (local/scp/s3) |
+| `pebblify_daemon_conversion_duration_seconds` | Histogram | —            | Conversion phase duration per job              |
+
+Existing `pebblify_keys_processed_total`, `pebblify_bytes_read_total`, etc. remain registered by `internal/prom.init()`. Daemon reuses them when calling `internal/migration`.
+
+---
+
+## Health
+
+Listener bound to `health.host:health.port`. Enabled only when `health.enable = true`.
+
+Reuses `internal/health.ProbeState` and `internal/health.Server` (existing types).
+
+### Semantics
+
+- `/healthz` (liveness): returns 200 as long as the daemon process is alive and listeners are serving. Never returns non-200 unless the process is about to crash. The ping ticker from `internal/health.PingTicker` keeps liveness alive between jobs.
+- `/readyz` (readiness): returns 200 only when the daemon is idle with an empty queue (ready to accept and immediately start a new job). Returns 503 Service Unavailable while a job is running or while jobs are queued. This allows external orchestrators to back off when the daemon is busy.
+
+State transitions:
+```
+startup          → SetStarted() + SetNotReady()
+config loaded    → (still not ready — listeners not up)
+all listeners up → SetReady()   (queue empty, no job running)
+job enqueued     → SetNotReady()
+job complete     → SetReady()   (if queue now empty; else stays NotReady)
+job failed       → SetReady()   (if queue now empty; else stays NotReady)
+shutdown gate    → SetNotReady() (permanently, until process exits)
+fatal exit       → process exits; readyz/healthz stop responding
+```
+
+---
+
+## Services Independence
+
+All three listeners (api, telemetry, health) bind independently in separate goroutines. A bind error on any single listener is a fatal startup error (exit 1). An I/O error on an established listener connection is logged at WARN and does not terminate the daemon.
+
+Each listener has its own `http.Server` with sensible timeouts:
+
+| Listener  | ReadHeaderTimeout | ReadTimeout | WriteTimeout | IdleTimeout |
+| :-------- | :---------------- | :---------- | :----------- | :---------- |
+| api       | 10s               | 30s         | 120s         | 60s         |
+| telemetry | 5s                | 5s          | 10s          | 30s         |
+| health    | 5s                | 5s          | 10s          | 30s         |
+
+---
+
+## Sequence Diagram (ASCII)
+
+```
+Client          API server      Queue       Worker          Storer(s)   Notifier
+  |                |              |             |               |           |
+  |--POST /v1/job->|              |             |               |           |
+  |                |--enqueue---->|             |               |           |
+  |<--202 Accepted-|              |             |               |           |
+  |                |              |--dequeue--->|               |           |
+  |                |              |             |--download---->|           |
+  |                |              |             |<--done--------|           |
+  |                |              |             |--convert+verify---------->|
+  |                |              |             |<--done--------------------|
+  |                |              |             |--repack+store------------>|
+  |                |              |             |<--done--------------------|
+  |                |              |             |--cleanup                  |
+  |                |              |             |--notify------------------->
+  |                |              |             |<--done---------------------|
+  |--GET /v1/status|              |             |               |           |
+  |<--200 idle-----|              |             |               |           |
+```
+
+---
+
+## systemd Unit Ownership
+
+**Decision locked 2026-04-18**: the systemd unit file is owned by `@container-engineer`, not `@lead-dev`.
+
+File paths (to be produced by `@container-engineer`):
+
+| File                             | Description                                              |
+| :------------------------------- | :------------------------------------------------------- |
+| `systemd/pebblify.service`       | Canonical systemd unit template checked into the repo    |
+| `systemd/pebblify.env.example`   | Example env file stub with all `PEBBLIFY_*` keys empty   |
+
+The `install-systemd-daemon` Makefile target (owned by `@lead-dev`) copies these files to `/etc/systemd/system/pebblify.service` and `/etc/pebblify/.env` during installation. `@lead-dev` does not author the unit file content; it reads the file from the repository and copies it. This keeps systemd unit syntax exclusively in `@container-engineer`'s scope.
+
+**CLAUDE.md scope amendment required**: `systemd/` and `**/*.service` files are NOT currently listed in `@container-engineer`'s write scope. See "CLAUDE.md Amendment Flag" in `docs/roadmap/v0.4.0.md`. CEO must extend the scope matrix before step 5 (GitHub issue creation) can include systemd work under `@container-engineer`.
+
+---
+
+## S3 Sub-module Constraint
+
+`@lead-dev` must import only these aws-sdk-go-v2 sub-modules:
+
+```
+github.com/aws/aws-sdk-go-v2/config
+github.com/aws/aws-sdk-go-v2/credentials
+github.com/aws/aws-sdk-go-v2/service/s3
+```
+
+No other `aws/aws-sdk-go-v2` service packages (e.g. `service/sts`, `service/iam`, `feature/s3/manager`) may be added without explicit CEO approval. The goal is to keep the binary size reasonable; the full SDK adds many unused service clients. `@lead-dev` must verify that only these three sub-modules appear as direct dependencies in `go.mod` after running `go mod tidy`.
+
+---
+
+## Makefile Targets (authored by @lead-dev)
+
+`@lead-dev` writes these targets in `Makefile`. This spec defines requirements only; `@lead-dev` owns the implementation.
+
+### `install-cli`
+
+Replaces the existing `install` target. Installs the pebblify binary for the current user. Cross-platform: works on all four build targets (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64).
+
+Requirements:
+- Build with native `CGO_ENABLED=0`.
+- Install to `$(GOPATH)/bin/pebblify` if `GOPATH` is set and writable; else `/usr/local/bin/pebblify`.
+- Does not require root.
+
+### `install-systemd-daemon`
+
+Installs daemon for system-wide use under systemd. **Linux-only**. Requires root (`sudo`). Must fail with a clear error message if run on a non-Linux platform.
+
+Requirements:
+- Binary installed to `/usr/local/bin/pebblify`.
+- Creates `/etc/pebblify/` directory (mode 0750, owned root:root).
+- Creates `/etc/pebblify/config.toml` from an embedded template with sane defaults (api.enable=false, health.enable=true, telemetry.enable=true). Does NOT overwrite if file already exists.
+- Copies `systemd/pebblify.env.example` to `/etc/pebblify/.env`. Mode 0600, owned root:root. Does NOT overwrite if file already exists.
+- Copies `systemd/pebblify.service` (authored by `@container-engineer`) to `/etc/systemd/system/pebblify.service`. Does NOT overwrite if file already exists.
+- Does NOT run `systemctl enable` or `systemctl start`. The operator does this manually.
+- Emits a post-install message listing next steps (fill .env, enable unit).
+
+The unit file content requirements (for `@container-engineer`'s reference when authoring `systemd/pebblify.service`):
+- `EnvironmentFile=/etc/pebblify/.env`
+- `ExecStart=/usr/local/bin/pebblify daemon`
+- `Restart=on-failure`
+- `User=pebblify` (operator creates this user; Makefile does not create system users)
+
+### `clean` extensions
+
+Add cleanup of any local `pebblify-darwin-*` artifacts alongside existing `pebblify-linux-*` cleanup.
+
+---
+
+## Docker Compose Reference (`docker-compose.daemon.yml`)
+
+Authored by `@container-engineer`. This spec provides a reference layout as a code block; `@container-engineer` produces the actual file.
+
+```yaml
+# Reference layout — actual file authored by @container-engineer
+version: "3.9"
+
+services:
+  pebblify-daemon:
+    image: ghcr.io/dockermint/pebblify:v0.4.0
+    command: daemon
+    env_file:
+      - .env
+    ports:
+      - "2324:2324"   # API
+      - "2325:2325"   # Health
+      - "2323:2323"   # Telemetry/Prometheus
+    volumes:
+      - ./config.toml:/etc/pebblify/config.toml:ro
+      - snapshots:/snapshots
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:2325/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  snapshots:
+```
+
+`.env` file alongside the compose file holds all `PEBBLIFY_*` secrets (gitignored).
+
+`config.toml` must configure `save.local.local_save_directory` to `/snapshots` to match the volume mount.
+
+Note for macOS operators: Docker and Podman are the supported paths for running the daemon on macOS. There is no native daemon install for macOS.
+
+---
+
+## CLI Invariance
+
+The switch statement in `cmd/pebblify/main.go` gains one new case, guarded by a Linux build tag:
+
+```
+// +build linux
+
+case "daemon":
+    daemonCmd(os.Args[2:])
+```
+
+On non-Linux builds, the `"daemon"` case is replaced by a stub that prints `pebblify daemon is not supported on this platform; use Docker or Podman` and exits 1.
+
+`daemonCmd` validates that no positional arguments or conversion flags are passed (exits 1 with usage if any are present), reads the config path from `PEBBLIFY_CONFIG_PATH` or defaults to `./config.toml`, loads config, and calls `daemon.Run(cfg)`.
+
+Existing cases (`level-to-pebble`, `recover`, `verify`, `completion`) are not modified.
+
+---
+
+## Dependency Recommendations
+
+| Need                       | Recommended package                                      | Decision owner | Status         |
+| :------------------------- | :------------------------------------------------------- | :------------- | :------------- |
+| TOML parsing               | `github.com/BurntSushi/toml` v1.x                        | `@lead-dev`    | Pending eval   |
+| S3 uploads                 | `github.com/aws/aws-sdk-go-v2/config` + `credentials` + `service/s3` | `@lead-dev` | **CEO confirmed** — only these 3 sub-modules |
+| Telegram notify            | `github.com/go-telegram-bot-api/telegram-bot-api/v5`     | `@lead-dev`    | Pending eval   |
+| SCP / SSH transport        | `golang.org/x/crypto/ssh`                                | `@lead-dev`    | Pending eval   |
+
+The `aws-sdk-go-v2` fallback (hand-rolled SigV4) is removed from scope; CEO confirmed the library. For Telegram, if `@lead-dev` rejects `go-telegram-bot-api`, the fallback is raw Telegram Bot API over `net/http` with `encoding/json`. Zero additional deps.
+
+---
+
+## Hand-off
+
+| Agent               | Scope files                                                                             | Action                                                    |
+| :------------------ | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------- |
+| `@lead-dev`         | `go.mod`, `go.sum`, `Makefile`                                                          | Add deps (3 aws sub-modules only); add install-cli, install-systemd-daemon (Linux-only) |
+| `@go-developer`     | `internal/daemon/**/*.go`, `cmd/pebblify/main.go`                                       | Implement all packages and CLI wiring; add linux build tag to daemon.go |
+| `@container-engineer` | `docker-compose.daemon.yml`, `systemd/pebblify.service`, `systemd/pebblify.env.example` | Produce compose file + systemd unit + env stub (pending CLAUDE.md scope amendment) |
+| `@qa`               | `internal/daemon/**/*_test.go`                                                          | Unit + integration tests; mutation testing                |
+| `@reviewer`         | read-only                                                                               | APPROVE or BLOCK                                          |
+| `@sysadmin`         | git operations                                                                          | Branch, commit, PR                                        |
+| `@devops`           | no changes in this feature branch                                                       | —                                                         |
+| `@technical-writer` | invoked post-merge; owns README + docs/                                                 | Document daemon mode; split install docs by platform      |

--- a/docs/specs/documentation-refresh.md
+++ b/docs/specs/documentation-refresh.md
@@ -1,0 +1,114 @@
+# Spec: Documentation Refresh — v0.4.0
+
+Owner: `@software-architect`
+Date: 2026-04-18
+Feature branch: `docs/release-v0.4.0`
+Implementation owner: `@technical-writer`
+
+---
+
+## Objective
+
+Update all user-facing documentation to cover the v0.4.0 feature set: daemon mode, CI attestations, Podman support, and the new Makefile targets. This work is invoked post-merge (step 14 of the CLAUDE.md workflow), after all three feature branches are on `main`.
+
+**Platform constraint for docs**: `pebblify daemon` is Linux-only at runtime. All install documentation must be split by platform:
+- `install-cli`: cross-platform (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64). Document for all four targets.
+- `install-systemd-daemon`: Linux-only. Clearly labeled. Do not imply macOS support.
+- `install-podman` / Quadlet: Linux-native; macOS users use Podman Desktop (which provides a Linux VM). Document both paths with clear platform callouts.
+- No `install-launchd-daemon` documentation exists or should be mentioned.
+
+macOS users who want to run the daemon must use Docker or Podman. The quickstart and daemon docs must include a "macOS users" callout directing them to the Docker Compose or Podman Quadlet path.
+
+---
+
+## Files to Produce or Update
+
+All files listed below are in `@technical-writer`'s exclusive write scope. No other agent touches these files.
+
+### `README.md`
+
+Additions:
+- New section **Daemon mode** between the existing CLI usage section and the Docker section. Content: one-paragraph description, quickstart (download config, fill .env, run `pebblify daemon` on Linux or via Docker/Podman on macOS), link to `docs/markdown/daemon-quickstart.md`. Include a "macOS users" callout directing to Docker Compose or Podman path.
+- Update **Installation** section: split into three subsections: (1) CLI install (`make install-cli`, cross-platform), (2) Daemon install (`make install-systemd-daemon`, Linux-only, clearly labeled), (3) Podman install (`make install-podman`, Linux-native; macOS via Podman Desktop).
+- Add **Podman** subsection in Installation referencing `make install-podman`.
+- Update **Build** section: note that darwin/amd64 and darwin/arm64 binaries are now included in releases.
+- Add **Artifact attestation** paragraph: how to run `gh attestation verify` with the GHCR image and release binaries.
+
+Do not remove or reorganize existing CLI content. Additions only, plus targeted in-place updates to Installation and Build.
+
+### `docs/markdown/`
+
+New files:
+
+| File                                    | Content                                                                 |
+| :-------------------------------------- | :---------------------------------------------------------------------- |
+| `docs/markdown/daemon-quickstart.md`    | 5-minute tutorial: install, config.toml minimal setup, run daemon, POST job via curl |
+| `docs/markdown/daemon-config.md`        | Full config schema reference: every TOML key, type, default, env override |
+| `docs/markdown/daemon-api.md`           | API reference: POST /v1/job, GET /v1/status, auth modes, error codes    |
+| `docs/markdown/telegram-integration.md` | Step-by-step: create Telegram bot, obtain token, set channel_id         |
+| `docs/markdown/s3-setup.md`             | S3 config walkthrough: IAM policy, bucket, access key, save_path        |
+| `docs/markdown/release-automation.md`  | CI attestation docs: workflow overview, gh attestation verify examples  |
+
+### `docs/docusaurus/`
+
+New MDX files (site-facing user guide):
+
+| File                                          | Content                                                          |
+| :-------------------------------------------- | :--------------------------------------------------------------- |
+| `docs/docusaurus/install-cli.mdx`             | CLI install options (go install, binary download, make install-cli) — cross-platform, all four targets |
+| `docs/docusaurus/install-systemd-daemon.mdx`  | make install-systemd-daemon walkthrough + systemctl steps — **Linux only**, labeled prominently |
+| `docs/docusaurus/install-podman.mdx`          | make install-podman walkthrough + systemctl --user steps — Linux-native; macOS-via-Podman-Desktop path documented separately within the same page |
+| `docs/docusaurus/daemon-quickstart.mdx`       | Adapted from markdown quickstart; Docusaurus admonitions/tabs OK |
+| `docs/docusaurus/configuration-reference.mdx` | Full TOML key reference with collapsible sections per [section]  |
+| `docs/docusaurus/telegram-integration.mdx`   | Adapted from markdown; step-by-step with screenshots placeholders |
+| `docs/docusaurus/s3-setup.mdx`               | Adapted from markdown                                            |
+
+---
+
+## Content Requirements
+
+### Daemon config reference
+
+Must document every TOML key with:
+- Key path (e.g. `api.authentification_mode`)
+- Type
+- Default value
+- Valid values or format
+- Corresponding env var (if any)
+- Security note (if key interacts with secrets)
+
+### API reference
+
+Must include:
+- Full request/response JSON schemas
+- All HTTP status codes returned by each endpoint and their meaning
+- `curl` examples for both auth modes
+- A note that `authentification_mode = unsecure` is not recommended for production
+
+### Attestation docs
+
+Must include:
+- Explanation of SLSA provenance and SBOM
+- Exact `gh attestation verify` commands for binaries and Docker image
+- Link to https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations
+
+---
+
+## Tone and Style
+
+- Technical audience: blockchain node operators and DevOps engineers.
+- Direct, imperative voice. No marketing filler.
+- Code blocks for all CLI commands, config snippets, and JSON examples.
+- No emojis in documentation files.
+
+---
+
+## Hand-off
+
+| Agent               | Scope files                                                               | Action                             |
+| :------------------ | :------------------------------------------------------------------------ | :--------------------------------- |
+| `@technical-writer` | `README.md`, `docs/markdown/*.md`, `docs/docusaurus/*.mdx`               | Produce all files listed above     |
+| `@reviewer`         | read-only                                                                 | Audit for CLAUDE.md compliance     |
+| `@sysadmin`         | git operations                                                            | Branch, commit, PR                 |
+
+Note: `@technical-writer` should reference `docs/specs/daemon-mode.md`, `docs/specs/podman-support.md`, and `docs/specs/ci-attestations-arm64.md` as the authoritative source for all technical details. Do not invent behavior not covered in the specs.

--- a/docs/specs/podman-support.md
+++ b/docs/specs/podman-support.md
@@ -1,0 +1,134 @@
+# Spec: Podman Quadlet Support
+
+Owner: `@software-architect`
+Date: 2026-04-18
+Last revised: 2026-04-18 (CEO decisions locked — cross-ref daemon-mode.md)
+Feature branch: `feat/podman-support`
+Implementation owners: `@lead-dev` (Makefile), `@container-engineer` (Quadlet file)
+
+---
+
+## Objective
+
+Provide a single `make install-podman` target that deploys Pebblify daemon as a rootless Podman Quadlet for the current user. No root required. No systemd unit is enabled by the target; the operator does that manually.
+
+**Platform**: Podman Quadlet requires a Linux host with systemd user session support. macOS users may use Podman Desktop, which provides a Linux VM; the `install-podman` target is not guaranteed to work on macOS without Podman Desktop's VM layer. The target does not guard against macOS explicitly but emits a clear warning if `systemctl --user status` is unavailable.
+
+---
+
+## Prerequisite
+
+Feature branch `feat/daemon-mode` must be merged to `develop` before this branch is cut. The Quadlet depends on the daemon config path `~/.pebblify/config.toml` established in the daemon spec.
+
+---
+
+## Makefile Target (`@lead-dev`)
+
+Target name: `install-podman`
+
+Location: `Makefile` (owned by `@lead-dev`)
+
+Requirements:
+- Check that `podman` is on `PATH`; exit with a clear error message if not found.
+- Check that systemd user session is available (`systemctl --user status`); warn but do not exit if not (some CI environments lack it).
+- Create `~/.config/containers/systemd/` if it does not exist.
+- Copy (or generate) the Quadlet file to `~/.config/containers/systemd/pebblify.container`. Do NOT overwrite if the file already exists (emit a message and skip).
+- Create `~/.pebblify/` directory (mode 0700) if it does not exist.
+- Create `~/.pebblify/config.toml` from an embedded template with sane defaults. Do NOT overwrite if already exists.
+- Create `~/.pebblify/.env` with all `PEBBLIFY_*` env var stubs as empty strings. Mode 0600. Do NOT overwrite if already exists.
+- Emit a post-install message:
+
+```
+Pebblify Quadlet installed.
+Next steps:
+  1. Edit ~/.pebblify/config.toml
+  2. Fill in secrets: ~/.pebblify/.env
+  3. Reload user units: systemctl --user daemon-reload
+  4. Start: systemctl --user start pebblify
+  5. Enable on login: systemctl --user enable pebblify
+```
+
+---
+
+## Quadlet File (`@container-engineer`)
+
+File path: `~/.config/containers/systemd/pebblify.container`
+
+This file is authored by `@container-engineer`. The spec defines required directives; `@container-engineer` fills in values and any additional directives per Quadlet format rules.
+
+### Required Directives
+
+```ini
+[Unit]
+Description=Pebblify daemon (LevelDB → PebbleDB conversion service)
+After=network-online.target
+
+[Container]
+Image=ghcr.io/dockermint/pebblify:v0.4.0
+Exec=daemon
+PublishPort=2324:2324
+PublishPort=2325:2325
+PublishPort=2323:2323
+Volume=%h/.pebblify/config.toml:/etc/pebblify/config.toml:ro,z
+Volume=pebblify-snapshots:/snapshots:z
+EnvironmentFile=%h/.pebblify/.env
+
+[Service]
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+Notes:
+- `%h` is the systemd specifier for `$HOME`; valid in Quadlet files.
+- `:z` relabels the volume for SELinux; safe to include even on non-SELinux systems.
+- Port 2324 = API, port 2325 = Health, port 2323 = Telemetry.
+- `Exec=daemon` sets the container command to `pebblify daemon`.
+- `User=` directive is NOT needed; Quadlet runs rootless by default as the invoking user.
+- `pebblify-snapshots` is a named Podman volume; `@container-engineer` decides whether to also provide a `pebblify-snapshots.volume` Quadlet file or document manual creation.
+
+### Volume for snapshots
+
+`config.toml` inside the container must point `save.local.local_save_directory` to `/snapshots`. The default template created by `make install-podman` pre-sets this value.
+
+---
+
+## Scope Boundary Clarification
+
+| Task                              | Owner                 |
+| :-------------------------------- | :-------------------- |
+| `Makefile` target `install-podman`| `@lead-dev`           |
+| Quadlet `.container` file content | `@container-engineer` |
+| Optional `.volume` Quadlet file   | `@container-engineer` |
+| systemd `.service` unit (system-wide daemon) | `@container-engineer` — see daemon-mode.md handoff |
+| `~/.pebblify/config.toml` template| `@lead-dev` (embedded in Makefile) |
+| `~/.pebblify/.env` stub template  | `@lead-dev` (embedded in Makefile) |
+
+`@lead-dev` does not write the `.container` file content. `@container-engineer` does not write Makefile lines.
+
+The Makefile target references the `.container` file by copying it from the repository (a checked-in template at a path owned by `@container-engineer`) or by embedding it inline in the Makefile as a heredoc. The two agents must coordinate on the delivery mechanism. Architect recommendation: `@container-engineer` checks in `deploy/quadlet/pebblify.container` as the canonical template; `@lead-dev` copies it in the Makefile target. This keeps the Quadlet syntax exclusively in `@container-engineer`'s scope.
+
+**Cross-reference**: `@container-engineer` also owns `systemd/pebblify.service` and `systemd/pebblify.env.example` (system-wide daemon install, used by `install-systemd-daemon`). See `docs/specs/daemon-mode.md` — "systemd Unit Ownership" section. Both the Quadlet file and the systemd unit are `@container-engineer`'s deliverables; scope amendment to CLAUDE.md is required before implementation begins (see `docs/roadmap/v0.4.0.md` — "CLAUDE.md Amendment Required").
+
+---
+
+## Out of Scope
+
+- Podman Pod support (multiple containers in a pod).
+- Podman secrets integration (beyond the `.env` file approach).
+- Auto-update via `podman auto-update` / `io.containers.autoupdate` label — may be added by `@container-engineer` as an optional directive.
+- Root-mode Podman (rootful); this spec is rootless-only.
+
+---
+
+## Hand-off
+
+| Agent               | Scope files                                                    | Action                                     |
+| :------------------ | :------------------------------------------------------------- | :----------------------------------------- |
+| `@lead-dev`         | `Makefile`                                                     | Add install-podman target                  |
+| `@container-engineer` | `deploy/quadlet/pebblify.container` (new file in their scope); also `systemd/pebblify.service` and `systemd/pebblify.env.example` (owned in daemon-mode branch) | Author Quadlet template; pending CLAUDE.md scope amendment for systemd files |
+| `@qa`               | no test files for Makefile targets; document manual verify     | —                                          |
+| `@reviewer`         | read-only                                                      | APPROVE or BLOCK                           |
+| `@sysadmin`         | git operations                                                 | Branch, commit, PR                         |
+| `@technical-writer` | invoked post-merge                                             | Document Podman install in docs/; note Linux-native and macOS-via-Podman-Desktop paths |


### PR DESCRIPTION
  ## Summary                                                                       
  - Amend CLAUDE.md scope matrix for @container-engineer (systemd units)                                                                                                                                                                                                                                                    
  - Add Security rule on env template placeholders                                 
  - Add .gitignore entry for Claude agent-memory                                                                                                                                                                                                                                                                            
  - Land v0.4.0 roadmap + 4 per-feature specs from @software-architect             
                                                                                                                                                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                                                                                                                                                              
  - [ ] CI green                                            
  - [ ] CodeRabbit clean on governance changes                                                                                                                                                                                                                                                                              
  - [ ] Merge into develop unblocks #32/#33/#34/#35   