### PR TITLE
ci: add darwin/arm64 target + artifact attestations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,15 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        goos: [linux]
-        goarch: [amd64, arm64]
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
     steps:
       - uses: actions/checkout@v6
 
@@ -62,6 +69,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: docker/setup-qemu-action@v4
+
       - uses: docker/setup-buildx-action@v4
 
       - name: Docker metadata
@@ -84,7 +93,7 @@ jobs:
         with:
           context: .
           push: false
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ github.sha }}
             REVISION=${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,12 @@ on:
   push:
     tags: ["v*"]
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
-  attestations: write
-
 jobs:
   build:
     name: Build binaries
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -54,9 +50,11 @@ jobs:
     name: Attest binaries
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
@@ -69,7 +67,7 @@ jobs:
           subject-path: artifacts/pebblify-*
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: artifacts/
           format: spdx-json
@@ -84,8 +82,17 @@ jobs:
   docker:
     name: Docker push
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      attestations: write
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
+
+      - name: Lowercase repo
+        id: repo
+        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v4
 
@@ -104,7 +111,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ steps.repo.outputs.name }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -136,14 +143,16 @@ jobs:
       - name: Attest Docker image provenance
         uses: actions/attest-build-provenance@v4
         with:
-          subject-name: ghcr.io/${{ github.repository }}
+          subject-name: ghcr.io/${{ steps.repo.outputs.name }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
   release:
     name: GitHub Release
     runs-on: ubuntu-latest
-    needs: [build, docker, attest-binaries]
+    needs: [build, attest-binaries]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,25 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:
     name: Build binaries
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        goos: [linux]
-        goarch: [amd64, arm64]
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
     steps:
       - uses: actions/checkout@v6
 
@@ -39,6 +49,37 @@ jobs:
         with:
           name: pebblify-${{ matrix.goos }}-${{ matrix.goarch }}
           path: pebblify-${{ matrix.goos }}-${{ matrix.goarch }}
+
+  attest-binaries:
+    name: Attest binaries
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          pattern: pebblify-*
+          merge-multiple: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: artifacts/pebblify-*
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: artifacts/
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v4
+        with:
+          subject-path: artifacts/pebblify-*
+          sbom-path: sbom.spdx.json
 
   docker:
     name: Docker push
@@ -78,6 +119,7 @@ jobs:
             org.opencontainers.image.base.name=alpine:3.22
 
       - name: Build & push
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -91,10 +133,17 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
 
+      - name: Attest Docker image provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
   release:
     name: GitHub Release
     runs-on: ubuntu-latest
-    needs: [build, docker]
+    needs: [build, docker, attest-binaries]
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
- release.yml build matrix: all 4 mandatory targets (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64) with fail-fast: false
- new attest-binaries job: SBOM via anchore/sbom-action@v0, provenance via actions/attest-build-provenance@v4, sbom attestation via actions/attest-sbom@v4
- docker job: multi-arch (linux/amd64, linux/arm64) + QEMU + provenance attestation on GHCR image push
- ci.yml docker job: multi-arch build (no push, no attestation)
- release job gated on attest-binaries completion

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended platform support: Binaries now available for ARM64 Linux and macOS, and additional macOS x86_64 configurations.

* **Chores**
  * Enhanced build security with cryptographic attestations for artifacts and container images.
  * Added Software Bill of Materials (SBOM) generation for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->