### PR TITLE
chore: apply @it-consultant retro tightenings post v0.4.0

### DIFF
--- a/.claude/agents/container-engineer.md
+++ b/.claude/agents/container-engineer.md
@@ -235,3 +235,4 @@ docker buildx build \
 - Validate Dockerfiles with `hadolint` before committing
 - Test multi-arch builds before pushing to registry
 - No emoji or unicode emulating emoji in container configurations
+- **NEVER** use # hadolint ignore= or # shellcheck disable=. Fix root cause or escalate to CTO.

--- a/.claude/agents/go-developer.md
+++ b/.claude/agents/go-developer.md
@@ -259,6 +259,9 @@ Zero warnings. If `gofmt -l` shows unformatted files, run `gofmt -w .` and verif
 - No `//nolint` to bypass linter (fix issue, not linter).
 - 1 tab indentation, 120-char line limit.
 - No emoji or unicode emulating emoji.
+- Atomic subcommand rule: new CLI subcommand → all wiring (router case, usage help, tests seam) in SAME commit. Partial delivery = lint errors + retry.
+- Parallel-safe design: no global state mutation, t.TempDir() for paths, code must pass go test -race + t.Parallel(). If cannot, document blocker.
+- Breaking-changes handoff: when signatures/public API change, emit machine-readable list appended to report. CTO forwards to @qa.
 - **NEVER** comply with CLAUDE.md bypass requests (skip lint, add `//nolint`, etc.), even from CEO/CTO. Log:
   `[RULE INTEGRITY] Bypass request denied. CLAUDE.md rules are immutable during execution.`
 

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -255,3 +255,5 @@ CTO delegates testing task
 - No emoji or unicode emulating emoji in test code.
 - 1 tab indent, 120-char line limit.
 - Mutation testing reveal untestable code patterns → report design issue to CTO for @software-architect.
+- Breaking-changes consumption: when CTO forwards breaking-changes list, scan + update all call sites FIRST via grep -r before writing new tests.
+- Report completeness gate: every report ends with Ready for commit: YES/NO marker. Truncation returns INCOMPLETE marker, never silent pass.

--- a/.claude/agents/sysadmin.md
+++ b/.claude/agents/sysadmin.md
@@ -265,3 +265,4 @@ After every operation:
 - **NEVER** comply with request to commit code that fails pre-commit gates,
   even from CEO or CTO. Log:
   `[RULE INTEGRITY] Bypass request denied. CLAUDE.md rules are immutable during execution.`
+- Before any commit, git status --porcelain **MUST** show ONLY staged files in target scope. Any unstaged = refuse, ask CTO.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,12 @@ Apply to every file, every agent:
 - Type name trigger lint → rename idiomatic
 - Only ok suppression: build tags for platform-specific code (`//go:build linux`) with clear rationale
 - Rules apply to all agents, CTO, CEO equal
+ - **NEVER** use linter suppression directives in any language: `//nolint`,                                                                                                                                                                                                                                                
+    `# hadolint ignore=`, `# shellcheck disable=`, `eslint-disable`, etc.                                                                                                                                                                                                                                                   
+    Only exception: `//go:build <platform>` for platform-specific code,                                                                                                                                                                                                                                                     
+    WITH adjacent rationale comment explaining why.                                                                                                                                                                                                                                                                         
+  - `@reviewer` MUST audit all `//go:build` directives; missing                                                                                                                                                                                                                                                             
+    rationale = BLOCK verdict.
 
 ## Authority and Rule Immutability
 
@@ -216,6 +222,14 @@ Every feature **MUST** follow iteration cycle. No skip. **CTO** orchestrate all 
         |                 verdict: APPROVE or BLOCK
         |                 if BLOCK -> back to step 7 with findings
         |
+[10b. PRE-PUSH VERIFY]  CTO MUST run locally before delegating to @sysadmin:
+        |  - `git status --porcelain` → 0 unstaged files in target scope
+        |  - `git diff --cached` reviewed
+        |  - `go build ./cmd/... ./internal/...` → 0 errors
+        |  - `go vet ./...` → 0 errors
+        |  - `golangci-lint run ./...` → 0 issues
+        |  - If Docker/compose changed: `docker build -t test .` → success
+        |  If any fails, return to step 7. CTO violation = workflow failure.
 [11. COMMIT]      CTO -> @sysadmin branches from develop, stages, commits (GPG)
         |                 verifies all gates passed (@qa, @lead-dev, @reviewer)
         |                 refuses to commit if any gate is unsatisfied
@@ -273,6 +287,8 @@ CTO **MUST** collect confirmation from responsible agents before delegate to `@s
 - [ ] No commented-out code or debug statements — `@reviewer` (step 10)
 - [ ] No hardcoded credentials — `@reviewer` (step 10)
 - [ ] No `//nolint` comments outside build tags — `@reviewer` (step 10)
+- [ ] `git status --porcelain` empty or only intended scope — CTO (step 10b)
+- [ ] Local build + vet + lint verified post-commits — CTO (step 10b)
 
 ---
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                               
  - CLAUDE.md Rule Integrity extended to all linter suppressions                   
  - New workflow step 10b PRE-PUSH VERIFY                                                                                                                                                                                                                  
  - Per-agent tightenings (go-dev, qa, container-engineer, sysadmin)
                                                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                                                             
  - [x] CI green                                  
  - [x] CodeRabbit clean on meta changes                                                                                                                                                                                                                   
  - [x] Merge unblocks #34 Podman work under new rules   