### PR TITLE
fix(container): remove hadolint ignore directives 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,12 @@ ARG TARGETARCH
 ARG VERSION=dev
 ARG REVISION=unknown
 
-# hadolint ignore=DL3018,SC2261
-RUN apk add --no-cache ca-certificates>=20260413 tzdata>=2026a
+# Alpine package pins are exact (including -rN revision). Rotation to a new
+# revision will break this build; bump manually on Alpine package updates.
+# Automated bumps deferred to v0.5.x (Renovate config).
+RUN apk add --no-cache \
+        ca-certificates=20260413-r0 \
+        tzdata=2026a-r0
 
 WORKDIR /build
 
@@ -46,11 +50,13 @@ LABEL org.opencontainers.image.title="Pebblify" \
       org.opencontainers.image.created="${CREATED}" \
       org.opencontainers.image.base.name="alpine:3.22"
 
-# hadolint ignore=DL3018,SC2261
+# Alpine package pins are exact (including -rN revision). Rotation to a new
+# revision will break this build; bump manually on Alpine package updates.
+# Automated bumps deferred to v0.5.x (Renovate config).
 RUN apk add --no-cache \
-        ca-certificates>=20260413 \
-        tzdata>=2026a \
-        wget>=1.25.0 \
+        ca-certificates=20260413-r0 \
+        tzdata=2026a-r0 \
+        wget=1.25.0-r1 \
     && addgroup -g 10000 pebblify \
     && adduser -D -H -u 10000 -G pebblify -s /sbin/nologin pebblify
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                               
  - Remove `# hadolint ignore=DL3018,SC2261` (Rule Integrity compliance)                                                                                                                                                                                   
  - Exact `-rN` apk pins instead of fuzzy `>=` (apk + hadolint both accept)                                                                                                                                                                                
  - Rotation warning documented                                                                                                                                                                                                                            
                                                                                   
  ## Test plan                                                                                                                                                                                                                                             
  - [ ] CI green (docker build + hadolint)                                         
  - [ ] CodeRabbit clean                            
  - [ ] Merge unblocks #34 Podman start                                                                                                                                                                                                                    
                                           
  Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image build reproducibility by pinning all Alpine package versions to exact releases, ensuring consistent and reliable container builds across deployment stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->