### PR TITLE
docs: add v0.4.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [v0.4.0](https://github.com/Dockermint/Pebblify/compare/v0.3.2...v0.4.0)
+
+### Features
+
+- feat(daemon): add `pebblify daemon` Linux-only subcommand with HTTP job queue API, FIFO queue with URL deduplication, LevelDB→PebbleDB pipeline, Prometheus metrics, and health probes ([#39](https://github.com/Dockermint/Pebblify/pull/39))
+- feat(daemon): add TOML config schema (config_version = 0) with env-var secret overlay for API, notify, telemetry, health, conversion, and save targets ([#39](https://github.com/Dockermint/Pebblify/pull/39))
+- feat(daemon): add store backends — local directory, SCP, and S3 via aws-sdk-go-v2 ([#39](https://github.com/Dockermint/Pebblify/pull/39))
+- feat(daemon): add Telegram notifier using stdlib net/http only; no third-party library ([#39](https://github.com/Dockermint/Pebblify/pull/39))
+- feat(daemon): add repack support for lz4, zstd, gzip, and none compression formats ([#39](https://github.com/Dockermint/Pebblify/pull/39))
+- feat(install): add `install-cli` (cross-platform) and `install-systemd-daemon` (Linux-only) Makefile targets; add systemd unit and placeholder env template ([#39](https://github.com/Dockermint/Pebblify/pull/39))
+- feat(install): add `install-podman` Makefile target and Podman Quadlet `.container` file for rootless daemon deployment ([#44](https://github.com/Dockermint/Pebblify/pull/44))
+
+### Bug Fixes
+
+- fix(container): remove `# hadolint ignore=` directives; replace fuzzy apk version constraints with exact pinned versions ([#43](https://github.com/Dockermint/Pebblify/pull/43))
+
+### Documentation
+
+- docs: v0.4.0 release documentation refresh — README installation split, daemon mode section, artifact attestation examples, and platform-split install guides ([#45](https://github.com/Dockermint/Pebblify/pull/45))
+- docs: land v0.4.0 roadmap and per-feature architecture specs ([#37](https://github.com/Dockermint/Pebblify/pull/37))
+
+### CI
+
+- ci: add darwin/amd64 and darwin/arm64 release binary targets to build matrix ([#38](https://github.com/Dockermint/Pebblify/pull/38))
+- ci: add SLSA provenance and SBOM attestations for release binaries and Docker images via `actions/attest-build-provenance` and `actions/attest-sbom` ([#38](https://github.com/Dockermint/Pebblify/pull/38))
+
+### Security
+
+- security(daemon): use HMAC-SHA-256 with constant-time comparison for API token validation to satisfy CodeQL timing-attack checks ([#39](https://github.com/Dockermint/Pebblify/pull/39))
+- security(daemon): reject symlink tar and zip entries during archive extraction to prevent path-traversal; covered by CodeQL analysis ([#39](https://github.com/Dockermint/Pebblify/pull/39))
+- security(daemon): enforce SSH known_hosts validation for SCP store; no host-key bypass permitted ([#39](https://github.com/Dockermint/Pebblify/pull/39))
+
+### Chore / Governance
+
+- chore: amend CLAUDE.md scope matrix to assign systemd unit files to `@container-engineer`; add env-template placeholder rule; land v0.4.0 governance docs ([#37](https://github.com/Dockermint/Pebblify/pull/37))
+- chore: apply `@it-consultant` retro tightenings — extend linter-suppression ban to all languages, add pre-push verify step 10b, per-agent scope tightenings ([#41](https://github.com/Dockermint/Pebblify/pull/41))
+
 ## [v0.3.2](https://github.com/Dockermint/Pebblify/compare/v0.3.1...v0.3.2)
 
 ### Bug Fixes


### PR DESCRIPTION
New entry at top of CHANGELOG.md following existing conventional-commit style. 7 category headings:

- Features: daemon mode + subsystems + install targets
- Bug Fixes: Dockerfile hadolint compliance
- Documentation: v0.4.0 docs refresh + roadmap/specs
- CI: darwin/arm64 target + SLSA provenance + SBOM
- Security: HMAC auth, symlink reject, SSH known_hosts
- Chore / Governance: scope matrix amendments + retro tightenings

All entries reference the merging PR.

Closes #46