### PR TITLE
fix(daemon): CodeRabbit round 2 polish on PR #48

### DIFF
--- a/cmd/pebblify/daemon.go
+++ b/cmd/pebblify/daemon.go
@@ -1,5 +1,10 @@
 //go:build linux
 
+// daemon.go: the daemon subcommand is Linux-only. Systemd socket activation,
+// sd_notify readiness signalling, /etc/pebblify configuration paths, and the
+// default known_hosts lookup all assume a Linux host; macOS and Windows
+// operators run the daemon through the container image instead.
+
 package main
 
 import (
@@ -37,7 +42,11 @@ const daemonShutdownTimeout = 30 * time.Second
 // arrives.
 func daemonCmd(args []string) {
 	fs := flag.NewFlagSet("daemon", flag.ContinueOnError)
-	fs.Usage = func() { daemonUsage(fs.Output()) }
+	fs.Usage = func() {
+		if err := daemonUsage(fs.Output()); err != nil {
+			fmt.Fprintf(os.Stderr, "pebblify daemon: write usage: %v\n", err)
+		}
+	}
 	showVersion := fs.Bool("version", false, "print daemon version and exit")
 	fs.BoolVar(showVersion, "V", false, "alias for --version")
 
@@ -50,7 +59,9 @@ func daemonCmd(args []string) {
 	}
 	if fs.NArg() != 0 {
 		fmt.Fprintf(os.Stderr, "pebblify daemon does not accept positional arguments\n\n")
-		daemonUsage(os.Stderr)
+		if err := daemonUsage(os.Stderr); err != nil {
+			fmt.Fprintf(os.Stderr, "pebblify daemon: write usage: %v\n", err)
+		}
 		os.Exit(1)
 	}
 
@@ -330,11 +341,11 @@ func (a *readinessAdapter) Ready() bool {
 	return true
 }
 
-// daemonUsage prints the subcommand help to w. Write errors are deliberately
-// ignored because the caller is always an already-failing CLI invocation; a
-// failed help write would mask the primary error.
-func daemonUsage(w io.Writer) {
-	_, _ = fmt.Fprintf(w, `pebblify daemon – long-running snapshot conversion service
+// daemonUsage prints the subcommand help to w and returns any write error so
+// callers can surface it on the primary error channel instead of silently
+// dropping a broken stderr pipe.
+func daemonUsage(w io.Writer) error {
+	_, err := fmt.Fprintf(w, `pebblify daemon – long-running snapshot conversion service
 
 Usage:
   pebblify daemon [options]
@@ -348,4 +359,8 @@ Configuration:
   PEBBLIFY_CONFIG_PATH (default: ./config.toml). Secrets are read from
   environment variables only; see docs/specs/daemon-mode.md.
 `)
+	if err != nil {
+		return fmt.Errorf("write daemon usage: %w", err)
+	}
+	return nil
 }

--- a/cmd/pebblify/daemon_register_linux.go
+++ b/cmd/pebblify/daemon_register_linux.go
@@ -1,5 +1,10 @@
 //go:build linux
 
+// daemon_register_linux.go: Linux build registers the real daemon entrypoint.
+// The sibling !linux file provides a stub that rejects the invocation with a
+// clear message. Splitting the registration this way keeps main.go free of
+// GOOS conditionals while preserving the Linux-only service semantics.
+
 package main
 
 // runDaemon is the Linux entrypoint wired into main's command switch. It

--- a/cmd/pebblify/daemon_register_other.go
+++ b/cmd/pebblify/daemon_register_other.go
@@ -1,5 +1,10 @@
 //go:build !linux
 
+// daemon_register_other.go: non-Linux build registers a stub that rejects the
+// daemon subcommand. The daemon depends on systemd integration and Linux-only
+// service paths, so on macOS and Windows it must run through the container
+// image; this file exists solely to keep main.go portable across GOOS targets.
+
 package main
 
 import (

--- a/internal/daemon/config/config.go
+++ b/internal/daemon/config/config.go
@@ -366,8 +366,25 @@ func validate(cfg *Config, secrets Secrets) error {
 	if err := validateSave(cfg, secrets); err != nil {
 		return err
 	}
+	if err := validateConversion(cfg); err != nil {
+		return err
+	}
 	if cfg.Queue.BufferSize < 1 {
 		return fmt.Errorf("%w: queue.buffer_size must be >= 1", ErrInvalidField)
+	}
+	return nil
+}
+
+// validateConversion rejects conversion-section values that would silently
+// demote the daemon to relative-path scratch usage. An empty
+// temporary_directory is a configuration bug: filepath.Join("", jobID) in the
+// runner yields a CWD-relative directory, so workspace paths end up in the
+// invoking user's current directory rather than the operator-blessed scratch
+// area. Require an explicit absolute-or-home-relative path up front.
+func validateConversion(cfg *Config) error {
+	if strings.TrimSpace(cfg.Conversion.TemporaryDirectory) == "" {
+		return fmt.Errorf("%w: conversion.temporary_directory must not be empty",
+			ErrInvalidField)
 	}
 	return nil
 }

--- a/internal/daemon/config/config_test.go
+++ b/internal/daemon/config/config_test.go
@@ -33,7 +33,7 @@ enable = false
 [health]
 enable = false
 
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 delete_source_snapshot = false
 
@@ -113,7 +113,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -145,7 +145,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -186,7 +186,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -214,7 +214,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -241,7 +241,7 @@ host = "127.0.0.1"
 port = -1
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -268,7 +268,7 @@ enable = false
 enable = true
 host = "127.0.0.1"
 port = 0
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -293,7 +293,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -339,7 +339,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -374,7 +374,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -409,7 +409,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -446,7 +446,7 @@ channel_id = "123"
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -480,7 +480,7 @@ channel_id = "123"
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -514,7 +514,7 @@ channel_id = ""
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -557,7 +557,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "` + tt.compression + `"
@@ -594,7 +594,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "` + codec + `"
@@ -631,7 +631,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -667,7 +667,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -739,7 +739,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -784,7 +784,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -819,7 +819,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -854,7 +854,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -886,7 +886,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"
@@ -956,7 +956,7 @@ enable = false
 enable = false
 [health]
 enable = false
-[convertion]
+[conversion]
 temporary_directory = "/tmp"
 [save]
 compression = "lz4"

--- a/internal/daemon/queue/queue.go
+++ b/internal/daemon/queue/queue.go
@@ -20,7 +20,6 @@ import (
 	"time"
 )
 
-
 // Sentinel errors returned by Queue operations.
 var (
 	// ErrDuplicate indicates the job's canonicalized URL is already running or queued.
@@ -34,24 +33,23 @@ var (
 )
 
 // defaultSchemePorts maps URL schemes to their default TCP port. Canonicalization
-// strips the port when it matches the default for the scheme.
+// strips the port when it matches the default for the scheme. The set mirrors
+// allowedSchemes so every scheme that survives validation has a documented
+// default port.
 var defaultSchemePorts = map[string]string{
 	"http":  "80",
 	"https": "443",
-	"ftp":   "21",
-	"ssh":   "22",
-	"sftp":  "22",
 }
 
 // allowedSchemes is the whitelist of URL schemes the daemon accepts as job
-// sources. Any other scheme (javascript, file, data, ...) is rejected at
-// canonicalization time so dangerous URLs never reach the runner.
+// sources. Only HTTP and HTTPS are admitted because runner.download uses
+// net/http; admitting ftp/sftp/ssh here would pass canonicalization only to
+// fail at download time with an opaque "unsupported protocol" error. Any
+// other scheme (javascript, file, data, ...) is rejected here so dangerous
+// URLs never reach the runner.
 var allowedSchemes = map[string]struct{}{
 	"http":  {},
 	"https": {},
-	"ftp":   {},
-	"sftp":  {},
-	"ssh":   {},
 }
 
 // Job is a single conversion request accepted from the API.
@@ -112,14 +110,14 @@ type Options struct {
 // in-flight, closing the race where the worker has pulled a job off ch but has
 // not yet acquired mu to mark it current.
 type FIFOQueue struct {
-	ch       chan Job
-	logger   *slog.Logger
-	mu       sync.Mutex
-	cond     *sync.Cond
-	pending  map[string]struct{} // canonical URL -> {} for pending jobs
-	current  *Job                // nil when idle
-	handoff  int                 // receives in flight but not yet marked current
-	closed   bool
+	ch      chan Job
+	logger  *slog.Logger
+	mu      sync.Mutex
+	cond    *sync.Cond
+	pending map[string]struct{} // canonical URL -> {} for pending jobs
+	current *Job                // nil when idle
+	handoff int                 // receives in flight but not yet marked current
+	closed  bool
 }
 
 // New returns an initialized FIFOQueue. BufferSize is clamped to a minimum of 1.
@@ -379,7 +377,7 @@ func Canonicalize(rawURL string) (string, error) {
 
 	scheme := strings.ToLower(u.Scheme)
 	if _, ok := allowedSchemes[scheme]; !ok {
-		return "", fmt.Errorf("unsupported url scheme %q: allowed schemes are http, https, ftp, sftp, ssh", scheme)
+		return "", fmt.Errorf("unsupported url scheme %q: only http and https are supported", scheme)
 	}
 	host := strings.ToLower(u.Hostname())
 	port := u.Port()

--- a/internal/daemon/runner/runner.go
+++ b/internal/daemon/runner/runner.go
@@ -457,6 +457,13 @@ func copyWithProgress(ctx context.Context, dst io.Writer, src io.Reader,
 // convert invokes internal/migration to produce a PebbleDB tree at pebbleDir.
 // The migration package expects the source to be a directory containing one
 // or more *.db subdirectories.
+//
+// internal/migration.RunLevelToPebble pre-dates context plumbing, so the call
+// runs in a child goroutine and we select on ctx.Done() to honour cancellation
+// from Stop or a daemon-wide shutdown. When ctx fires first, the goroutine is
+// left to complete on its own (logged as a known leak) and the caller gets
+// ctx.Err(); v0.5.x is expected to plumb context through the migration API so
+// this wrapper can collapse back to a direct call.
 func (r *jobRunner) convert(ctx context.Context, logger *slog.Logger,
 	levelDir, pebbleDir, tmpRoot string) error {
 	if err := ctx.Err(); err != nil {
@@ -469,14 +476,33 @@ func (r *jobRunner) convert(ctx context.Context, logger *slog.Logger,
 		Verbose:        false,
 		MetricsEnabled: false,
 	}
-	if err := migration.RunLevelToPebble(levelDir, pebbleDir, cfg, tmpRoot); err != nil {
-		return err
+
+	done := make(chan error, 1)
+	go func() {
+		done <- migration.RunLevelToPebble(levelDir, pebbleDir, cfg, tmpRoot)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return err
+		}
+		logger.Info("conversion complete")
+		return nil
+	case <-ctx.Done():
+		logger.Warn("conversion cancelled; background goroutine will drain",
+			"error", ctx.Err())
+		return ctx.Err()
 	}
-	logger.Info("conversion complete")
-	return nil
 }
 
 // verify runs internal/verify.Run against the source/destination pair.
+//
+// Mirrors convert: verify.Run does not yet accept a context, so the blocking
+// call is wrapped in a goroutine and multiplexed against ctx.Done(). On
+// cancellation the wrapper returns ctx.Err() and leaves the background call to
+// complete; the leak is bounded because verify has its own internal timeouts
+// and always terminates. See convert's doc comment for the v0.5.x roadmap.
 func (r *jobRunner) verify(ctx context.Context, logger *slog.Logger,
 	levelDir, pebbleDir string) error {
 	if err := ctx.Err(); err != nil {
@@ -489,11 +515,24 @@ func (r *jobRunner) verify(ctx context.Context, logger *slog.Logger,
 		StopOnError:   true,
 		Verbose:       false,
 	}
-	if err := verify.Run(levelDir, dataDir, cfg); err != nil {
-		return err
+
+	done := make(chan error, 1)
+	go func() {
+		done <- verify.Run(levelDir, dataDir, cfg)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return err
+		}
+		logger.Info("verification complete")
+		return nil
+	case <-ctx.Done():
+		logger.Warn("verification cancelled; background goroutine will drain",
+			"error", ctx.Err())
+		return ctx.Err()
 	}
-	logger.Info("verification complete")
-	return nil
 }
 
 // replaceDBTree swaps the original LevelDB subtree in the extracted archive
@@ -521,8 +560,11 @@ func (r *jobRunner) replaceDBTree(levelDir, pebbleDir string) error {
 }
 
 // fanOutUploads pushes archiveOut to every configured target in parallel.
-// An individual upload failure is WARN-level; an all-targets failure is a
-// job-level error.
+// Every configured target must succeed; any non-zero failure count aborts the
+// job so partial successes (e.g. local succeeded, S3 failed) never masquerade
+// as a completed backup. Individual failures are still WARN-logged per target
+// for operator visibility, and the aggregate is surfaced via errors.Join so
+// callers observing the return can unwrap each underlying cause.
 func (r *jobRunner) fanOutUploads(ctx context.Context, logger *slog.Logger,
 	archiveOut string) error {
 	if len(r.deps.Targets) == 0 {
@@ -554,18 +596,23 @@ func (r *jobRunner) fanOutUploads(ctx context.Context, logger *slog.Logger,
 	}
 	wg.Wait()
 
+	total := len(r.deps.Targets)
 	var failed int
-	var joined []error
+	joined := make([]error, 0, total)
 	for _, err := range errs {
 		if err != nil {
 			failed++
 			joined = append(joined, err)
 		}
 	}
-	if failed == len(r.deps.Targets) {
+	if failed == 0 {
+		return nil
+	}
+	if failed == total {
 		return fmt.Errorf("upload: all %d targets failed: %w", failed, errors.Join(joined...))
 	}
-	return nil
+	return fmt.Errorf("upload: %d of %d targets failed: %w",
+		failed, total, errors.Join(joined...))
 }
 
 // outputArchivePath builds the on-disk path for the repacked archive using

--- a/internal/daemon/runner/runner_test.go
+++ b/internal/daemon/runner/runner_test.go
@@ -328,7 +328,8 @@ func TestRunner_Start_StopsOnQueueShutdown(t *testing.T) {
 	}
 }
 
-// TestRunner_Stop_AfterContextCancel waits for Start to exit.
+// TestRunner_Stop_AfterContextCancel waits for Start to exit and asserts Start
+// returned nil after the context was cancelled.
 func TestRunner_Stop_AfterContextCancel(t *testing.T) {
 	t.Parallel()
 	fq := newFakeQueue(4)
@@ -339,7 +340,8 @@ func TestRunner_Stop_AfterContextCancel(t *testing.T) {
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() { _ = r.Start(ctx) }()
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
 
 	// Wait until the worker is deterministically blocked on Dequeue before cancelling.
 	fq.waitBlocking()
@@ -350,9 +352,19 @@ func TestRunner_Stop_AfterContextCancel(t *testing.T) {
 	if err := r.Stop(stopCtx); err != nil {
 		t.Errorf("Stop() error = %v", err)
 	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start() error = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return after context cancel and Stop()")
+	}
 }
 
-// TestRunner_Stop_Idempotent calling Stop twice returns nil both times.
+// TestRunner_Stop_Idempotent calling Stop twice returns nil both times and
+// asserts Start returned nil.
 func TestRunner_Stop_Idempotent(t *testing.T) {
 	t.Parallel()
 	fq := newFakeQueue(4)
@@ -363,7 +375,8 @@ func TestRunner_Stop_Idempotent(t *testing.T) {
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() { _ = r.Start(ctx) }()
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
 	// Wait until the worker is deterministically blocked on Dequeue.
 	fq.waitBlocking()
 	cancel()
@@ -375,5 +388,14 @@ func TestRunner_Stop_Idempotent(t *testing.T) {
 	}
 	if err := r.Stop(stopCtx); err != nil {
 		t.Errorf("second Stop() error = %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start() error = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return after context cancel and Stop()")
 	}
 }

--- a/internal/daemon/store/local/local.go
+++ b/internal/daemon/store/local/local.go
@@ -152,23 +152,31 @@ func copyFileAtomic(ctx context.Context, src, dst string) (retErr error) {
 }
 
 // fsyncDir opens destDir and issues Sync so the directory entry update from
-// the preceding Rename is flushed to disk. On platforms that do not support
-// directory fsync (Windows), Open returns an error that we treat as a no-op.
+// the preceding Rename is flushed to disk.
+//
+// ErrInvalid from Open is treated as a no-op because os.Open on a directory
+// is explicitly not supported on Windows and the daemon's build matrix spans
+// non-POSIX hosts; a legitimate ErrPermission on Linux must surface as a hard
+// failure so crash-consistency bugs are not silently ignored, so it is not
+// filtered here.
+//
+// The Sync and Close errors are combined via errors.Join so the caller sees
+// both failure modes when a bad fsync is followed by a failing close (e.g.
+// a disk that went read-only mid-operation).
 func fsyncDir(destDir string) error {
 	d, err := os.Open(destDir)
 	if err != nil {
-		// Directories cannot be opened for fsync on every platform; treat
-		// that path as best-effort rather than a hard failure.
-		if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrInvalid) {
+		if errors.Is(err, os.ErrInvalid) {
 			return nil
 		}
 		return err
 	}
-	if syncErr := d.Sync(); syncErr != nil {
-		_ = d.Close()
-		return syncErr
+	syncErr := d.Sync()
+	closeErr := d.Close()
+	if syncErr != nil || closeErr != nil {
+		return errors.Join(syncErr, closeErr)
 	}
-	return d.Close()
+	return nil
 }
 
 // copyWithContext is io.Copy that checks ctx.Done() every 1 MiB chunk.

--- a/internal/daemon/store/scp/scp.go
+++ b/internal/daemon/store/scp/scp.go
@@ -317,13 +317,19 @@ func runSCPSink(ctx context.Context, session *ssh.Session, localPath string,
 	}
 
 	if err := transferFile(ctx, stdin, reader, localPath, info, remoteFile); err != nil {
+		// Close the session BEFORE Wait so the readAck helper goroutine (blocked
+		// on r.ReadByte from the session's stdout) unblocks. Without this a
+		// wedged peer would leave Wait blocking forever because stdout never
+		// EOFs, re-introducing the daemon-worker hang this teardown prevents.
 		_ = stdin.Close()
+		_ = session.Close()
 		_ = session.Wait()
 		stderrWG.Wait()
 		return annotateWithStderr(err, &stderrBuf)
 	}
 
 	if err := stdin.Close(); err != nil {
+		_ = session.Close()
 		_ = session.Wait()
 		stderrWG.Wait()
 		return annotateWithStderr(fmt.Errorf("scp sink: close stdin: %w", err), &stderrBuf)

--- a/internal/daemon/store/scp/scp_test.go
+++ b/internal/daemon/store/scp/scp_test.go
@@ -404,13 +404,22 @@ func TestSCPTarget_Name(t *testing.T) {
 
 // ---- loadHostKeyCallback ----
 
-// TestLoadHostKeyCallback_MissingKnownHostsFile returns ErrKnownHosts when the
-// ~/.ssh/known_hosts file does not exist. We test this by pointing HOME at a
-// temporary directory that has no .ssh directory.
+// TestLoadHostKeyCallback_MissingKnownHostsFile returns ErrKnownHosts when no
+// known_hosts file can be found at any candidate path. The test controls all
+// three candidates via environment variables:
+//
+//   - PEBBLIFY_SCP_KNOWN_HOSTS is set to a non-existent path so the env-var
+//     branch is exercised but fails.
+//   - HOME is set to a temporary directory without .ssh so the per-user path
+//     also fails.
+//
+// /etc/pebblify/known_hosts is a Pebblify-specific path that does not exist
+// in CI or developer environments, so the system-path branch also fails.
 func TestLoadHostKeyCallback_MissingKnownHostsFile(t *testing.T) {
-	// No t.Parallel() — modifies HOME env var.
+	// No t.Parallel() — modifies HOME and PEBBLIFY_SCP_KNOWN_HOSTS env vars.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv(envKnownHosts, filepath.Join(home, "nonexistent_known_hosts"))
 
 	_, err := loadHostKeyCallback()
 	if !errors.Is(err, ErrKnownHosts) {

--- a/internal/daemon/telemetry/telemetry_test.go
+++ b/internal/daemon/telemetry/telemetry_test.go
@@ -117,9 +117,9 @@ func TestCollectors_RecordJobEnd_Success_SetsCompletedAndClearsActive(t *testing
 	if !strings.Contains(body, `status="completed"`) {
 		t.Errorf("RecordJobEnd success: missing completed label in: %s", body)
 	}
-	// Active must be reset to 0.
-	if strings.Contains(body, "active_end} 1") {
-		t.Errorf("RecordJobEnd: active still 1 after job end: %s", body)
+	// Active must be reset to 0. Unlabeled gauge is exposed as "t_active_end <value>" (no braces).
+	if !strings.Contains(body, "t_active_end 0") {
+		t.Errorf("RecordJobEnd: active not reset to 0 after job end: %s", body)
 	}
 }
 
@@ -221,9 +221,9 @@ func TestCollectors_AddBytesDownloaded_ZeroAndNegativeSkipped(t *testing.T) {
 	c.AddBytesDownloaded(-100)
 
 	body := scrapeMetrics(t, reg)
-	// Counter should remain at 0.
-	if strings.Contains(body, "bytes_dl_zero} 1") {
-		t.Errorf("AddBytesDownloaded zero/negative incremented counter: %s", body)
+	// Counter should remain at 0. Unlabeled counter is exposed as "t_bytes_dl_zero <value>" (no braces).
+	if !strings.Contains(body, "t_bytes_dl_zero 0") {
+		t.Errorf("AddBytesDownloaded zero/negative incremented counter, expected t_bytes_dl_zero 0 in: %s", body)
 	}
 }
 


### PR DESCRIPTION
Final pre-v0.4.0-tag hardening.

cmd/pebblify:
- daemon.go + daemon_register_{linux,other}.go: add adjacent rationale comments to //go:build tags per new CLAUDE.md rule.
- daemonUsage returns error; callers surface write failures.

internal/daemon/config:
- validateConversion rejects empty conversion.temporary_directory. Empty value caused filepath.Join(empty, jobID) to produce relative paths breaking every downstream step.

internal/daemon/queue:
- allowedSchemes narrowed to http/https only. runner.download uses net/http; ftp/sftp/ssh were dead branches that would silently fail at runtime.

internal/daemon/runner:
- fanOutUploads returns errors.Join over all upload errors when any target fails (partial success = job failure, per spec).
- convert + verify now wrap blocking calls in goroutines multiplexed against ctx.Done(). Cancellation returns ctx.Err() and logs the bounded background drain. v0.5.x deprecates the non-context migration API.

internal/daemon/store/local:
- fsyncDir combines sync + close errors via errors.Join; drops the too-broad ErrPermission swallow (only Windows ErrInvalid remains as best-effort).

internal/daemon/store/scp:
- Teardown: session.Close() BEFORE session.Wait() so readAck goroutine unblocks when peer is wedged.
- Tests exercise PEBBLIFY_SCP_KNOWN_HOSTS env branch via t.Setenv to isolate from system known_hosts paths.

Tests:
- runner_test captures Start error via channel + selects after Stop/cancel; asserts nil (no silent failure).
- telemetry_test assertions fixed — unlabeled Prometheus metrics expose as `name value` not `name{labels} value`. Replaced vacuous Contains checks with positive assertions.
- config_test fixtures updated for new conversion schema + non-empty temporary_directory requirement.

Checks:
- go test ./... -race -timeout 180s -> all PASS
- golangci-lint run ./... -> 0 issues
- 4-target cross-compile -> PASS

Part of #49 (continuation)