### PR TITLE
fix(daemon): CodeRabbit round 3 on PR #48

### DIFF
--- a/internal/daemon/config/config.go
+++ b/internal/daemon/config/config.go
@@ -23,12 +23,17 @@ const SupportedConfigVersion = 0
 const DefaultQueueBufferSize = 64
 
 // Compression codec identifiers accepted by the save.compression field.
+//
+// Every codec listed here MUST be implemented end-to-end by
+// internal/daemon/repack and internal/daemon/store. Adding a constant without
+// the downstream wiring would let a TOML file pass Load() and then fail at
+// repack time with an opaque error. "zip" is deliberately absent because
+// repack.Compress only emits tar-based archives.
 const (
 	CompressionNone = "none"
 	CompressionLZ4  = "lz4"
 	CompressionZstd = "zstd"
 	CompressionGzip = "gzip"
-	CompressionZip  = "zip"
 )
 
 // Authentication mode identifiers accepted by the api.authentification_mode field.
@@ -348,9 +353,13 @@ func expandHome(p string) (string, error) {
 }
 
 // validate enforces cross-field invariants defined in the daemon spec.
+//
+// SupportedConfigVersion is the maximum version this loader understands, so
+// only versions strictly greater than it are rejected. Older schema versions
+// are accepted; the loader is backwards compatible by contract.
 func validate(cfg *Config, secrets Secrets) error {
-	if cfg.General.ConfigVersion != SupportedConfigVersion {
-		return fmt.Errorf("%w: got %d, want %d", ErrUnsupportedConfigVersion,
+	if cfg.General.ConfigVersion > SupportedConfigVersion {
+		return fmt.Errorf("%w: got %d, max supported %d", ErrUnsupportedConfigVersion,
 			cfg.General.ConfigVersion, SupportedConfigVersion)
 	}
 
@@ -464,7 +473,7 @@ func validateNotify(cfg *Config, secrets Secrets) error {
 // validateSave enforces the save subsystem invariants across local, scp, and s3.
 func validateSave(cfg *Config, secrets Secrets) error {
 	switch cfg.Save.Compression {
-	case CompressionNone, CompressionLZ4, CompressionZstd, CompressionGzip, CompressionZip:
+	case CompressionNone, CompressionLZ4, CompressionZstd, CompressionGzip:
 	default:
 		return fmt.Errorf("%w: %q", ErrInvalidCompression, cfg.Save.Compression)
 	}

--- a/internal/daemon/queue/queue.go
+++ b/internal/daemon/queue/queue.go
@@ -200,27 +200,42 @@ func (q *FIFOQueue) Dequeue(ctx context.Context) (Job, error) {
 			return Job{}, ErrShuttingDown
 		}
 		jobCopy := job
-		q.releaseHandoff(&jobCopy)
+		if !q.releaseHandoff(&jobCopy) {
+			// Shutdown closed the queue between channel receive and handoff;
+			// drop the job so pending buffered items never promote to current
+			// after the Shutdown contract is already in effect.
+			q.logger.Warn("queue job dropped on shutdown handoff",
+				"job_id", job.ID, "url", RedactURL(job.URL))
+			return Job{}, ErrShuttingDown
+		}
 		return job, nil
 	}
 }
 
 // releaseHandoff decrements the handoff counter and either marks current (when
-// current is non-nil and a job was delivered) or leaves the slot idle. The
-// condition variable is broadcast in both cases so waitForCurrent revisits its
-// predicate. The canonical URL is removed from pending only when a job is
-// handed off; the drop-on-shutdown path owns its own pending deletion.
-func (q *FIFOQueue) releaseHandoff(job *Job) {
+// current is non-nil and the queue is still open) or leaves the slot idle. The
+// condition variable is broadcast in all cases so waitForCurrent revisits its
+// predicate. The canonical URL is removed from pending when a job was handed
+// off, regardless of whether it was promoted to current, so the dedup map does
+// not retain stale entries. The return value reports whether the job was
+// actually promoted to current: false means the queue was closed while the
+// receiver was in flight and the caller must treat the job as dropped.
+func (q *FIFOQueue) releaseHandoff(job *Job) bool {
 	q.mu.Lock()
 	q.handoff--
+	delivered := false
 	if job != nil {
 		if canonical, err := Canonicalize(job.URL); err == nil {
 			delete(q.pending, canonical)
 		}
-		q.current = job
+		if !q.closed {
+			q.current = job
+			delivered = true
+		}
 	}
 	q.cond.Broadcast()
 	q.mu.Unlock()
+	return delivered
 }
 
 // CompleteCurrent clears the current job slot and signals any goroutine

--- a/internal/daemon/queue/queue_test.go
+++ b/internal/daemon/queue/queue_test.go
@@ -565,6 +565,43 @@ func TestFIFOQueue_DequeueShutdownRace(t *testing.T) {
 	}
 }
 
+// TestFIFOQueue_Dequeue_AfterShutdownDiscardsBufferedJob verifies that a
+// Dequeue call that races with Shutdown does not deliver a buffered job that
+// was pulled from the channel after q.closed was set. The contract is:
+// pending buffered jobs are dropped by Shutdown; a Dequeue that loses the race
+// must return ErrShuttingDown rather than promoting a post-shutdown channel
+// receive to q.current.
+//
+// This test arranges the race explicitly: it enqueues a job so the channel
+// has a buffered item, calls Shutdown, then calls Dequeue on the already-closed
+// queue. Both operations happen sequentially here because Shutdown drains the
+// channel; the subsequent Dequeue must observe the closed channel and return
+// ErrShuttingDown.
+func TestFIFOQueue_Dequeue_AfterShutdownDiscardsBufferedJob(t *testing.T) {
+	t.Parallel()
+	q := newTestQueue(4)
+	if err := q.Enqueue(Job{ID: "j1", URL: "https://example.com/snap"}); err != nil {
+		t.Fatalf("Enqueue() error: %v", err)
+	}
+
+	shutCtx, shutCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer shutCancel()
+	if err := q.Shutdown(shutCtx); err != nil {
+		t.Fatalf("Shutdown() error: %v", err)
+	}
+
+	// After Shutdown drains the buffered job, the channel is closed.
+	// Dequeue must not deliver the already-drained job; it must return ErrShuttingDown.
+	_, err := q.Dequeue(context.Background())
+	if !errors.Is(err, ErrShuttingDown) {
+		t.Errorf("Dequeue after Shutdown with buffered job error = %v, want %v", err, ErrShuttingDown)
+	}
+	// q.current must remain nil: no job should have been promoted after shutdown.
+	if cur := q.Current(); cur != nil {
+		t.Errorf("Current() after shutdown Dequeue = %+v, want nil (buffered job must not be promoted)", cur)
+	}
+}
+
 // TestCleanURLPath covers the path-cleaning helper.
 func TestCleanURLPath(t *testing.T) {
 	t.Parallel()

--- a/internal/daemon/runner/runner.go
+++ b/internal/daemon/runner/runner.go
@@ -52,6 +52,13 @@ const (
 	// verifySamplePercent is the sampling rate passed to internal/verify. 0
 	// forces a full scan, matching the spec "no sampling skip in daemon".
 	verifySamplePercent = 0
+	// workspaceCleanupGrace caps how long cleanupWorkspace waits for any
+	// background goroutine spawned by convert/verify to release its file
+	// handles after ctx cancellation. The wait prevents os.RemoveAll from
+	// racing with an open PebbleDB, which would otherwise return EBUSY on
+	// Linux and permission-denied on Windows. A bounded timeout keeps the
+	// daemon responsive even when the leaked goroutine stalls permanently.
+	workspaceCleanupGrace = 30 * time.Second
 )
 
 // Sentinel errors returned by the runner.
@@ -260,11 +267,11 @@ func (r *jobRunner) runPipeline(ctx context.Context, logger *slog.Logger,
 		return err
 	}
 
-	if err := r.convert(ctx, logger, levelDir, ws.pebbleDir, ws.migrationTmp); err != nil {
+	if err := r.convert(ctx, logger, ws, levelDir); err != nil {
 		return fmt.Errorf("convert: %w", err)
 	}
 
-	if err := r.verify(ctx, logger, levelDir, ws.pebbleDir); err != nil {
+	if err := r.verify(ctx, logger, ws, levelDir); err != nil {
 		return fmt.Errorf("verify: %w", err)
 	}
 
@@ -311,6 +318,13 @@ func (r *jobRunner) failJob(ctx context.Context, logger *slog.Logger,
 }
 
 // workspace groups the scratch directories created for a single job.
+//
+// bgTasks tracks background goroutines spawned by convert and verify. The
+// internal/migration and internal/verify APIs do not yet accept a context, so
+// cancellation from Stop abandons the work goroutine while it still holds
+// file handles on the PebbleDB output. cleanupWorkspace must wait on bgTasks
+// with a bounded timeout before removing the scratch tree to avoid racing
+// the leaked goroutine on Windows and EBUSY paths on Linux.
 type workspace struct {
 	root         string
 	srcDir       string
@@ -318,6 +332,7 @@ type workspace struct {
 	pebbleDir    string
 	outDir       string
 	migrationTmp string
+	bgTasks      sync.WaitGroup
 }
 
 // prepareWorkspace creates <tmp>/<job_id>/{src,extracted,pebbledb,out,migration}.
@@ -341,12 +356,41 @@ func (r *jobRunner) prepareWorkspace(jobID string) (*workspace, error) {
 
 // cleanupWorkspace removes the job scratch tree. Errors are logged, not
 // returned, because cleanup must run on every exit path.
+//
+// Any background goroutine still holding file handles (convert or verify that
+// was abandoned on ctx cancellation) is awaited up to workspaceCleanupGrace
+// before removal. If the grace period elapses, cleanup proceeds anyway and the
+// lingering handles turn into a bounded partial-cleanup warning rather than an
+// indefinite leak. The timer goroutine cleanly exits on either path.
 func (r *jobRunner) cleanupWorkspace(logger *slog.Logger, ws *workspace) {
 	if ws == nil {
 		return
 	}
+	if err := waitWithTimeout(&ws.bgTasks, workspaceCleanupGrace); err != nil {
+		logger.Warn("cleanup workspace waited for background goroutines",
+			"path", ws.root, "grace", workspaceCleanupGrace, "error", err)
+	}
 	if err := os.RemoveAll(ws.root); err != nil {
 		logger.Warn("cleanup workspace failed", "path", ws.root, "error", err)
+	}
+}
+
+// waitWithTimeout blocks until wg.Wait returns or d elapses. Returns a
+// non-nil error only when the timeout fires; callers should treat a timeout
+// as a best-effort cleanup advisory rather than a fatal condition.
+func waitWithTimeout(wg *sync.WaitGroup, d time.Duration) error {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("background goroutines did not finish within %s", d)
 	}
 }
 
@@ -461,15 +505,16 @@ func copyWithProgress(ctx context.Context, dst io.Writer, src io.Reader,
 // internal/migration.RunLevelToPebble pre-dates context plumbing, so the call
 // runs in a child goroutine and we select on ctx.Done() to honour cancellation
 // from Stop or a daemon-wide shutdown. When ctx fires first, the goroutine is
-// left to complete on its own (logged as a known leak) and the caller gets
-// ctx.Err(); v0.5.x is expected to plumb context through the migration API so
-// this wrapper can collapse back to a direct call.
+// left to complete on its own (registered on ws.bgTasks so cleanupWorkspace
+// can await handle release before os.RemoveAll) and the caller gets ctx.Err();
+// v0.5.x is expected to plumb context through the migration API so this
+// wrapper can collapse back to a direct call.
 func (r *jobRunner) convert(ctx context.Context, logger *slog.Logger,
-	levelDir, pebbleDir, tmpRoot string) error {
+	ws *workspace, levelDir string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	logger.Info("conversion starting", "src", levelDir, "out", pebbleDir)
+	logger.Info("conversion starting", "src", levelDir, "out", ws.pebbleDir)
 	cfg := &migration.RunConfig{
 		Workers:        migrationWorkers,
 		BatchMemory:    migrationBatchMemoryMB,
@@ -478,8 +523,10 @@ func (r *jobRunner) convert(ctx context.Context, logger *slog.Logger,
 	}
 
 	done := make(chan error, 1)
+	ws.bgTasks.Add(1)
 	go func() {
-		done <- migration.RunLevelToPebble(levelDir, pebbleDir, cfg, tmpRoot)
+		defer ws.bgTasks.Done()
+		done <- migration.RunLevelToPebble(levelDir, ws.pebbleDir, cfg, ws.migrationTmp)
 	}()
 
 	select {
@@ -500,15 +547,17 @@ func (r *jobRunner) convert(ctx context.Context, logger *slog.Logger,
 //
 // Mirrors convert: verify.Run does not yet accept a context, so the blocking
 // call is wrapped in a goroutine and multiplexed against ctx.Done(). On
-// cancellation the wrapper returns ctx.Err() and leaves the background call to
-// complete; the leak is bounded because verify has its own internal timeouts
-// and always terminates. See convert's doc comment for the v0.5.x roadmap.
+// cancellation the wrapper returns ctx.Err() and leaves the background call
+// to complete; the goroutine is registered on ws.bgTasks so cleanupWorkspace
+// can wait (bounded by workspaceCleanupGrace) for file handles to release
+// before removing the scratch tree. See convert's doc comment for the v0.5.x
+// roadmap.
 func (r *jobRunner) verify(ctx context.Context, logger *slog.Logger,
-	levelDir, pebbleDir string) error {
+	ws *workspace, levelDir string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	dataDir := filepath.Join(pebbleDir, "data")
+	dataDir := filepath.Join(ws.pebbleDir, "data")
 	logger.Info("verification starting", "src", levelDir, "out", dataDir)
 	cfg := &verify.Config{
 		SamplePercent: verifySamplePercent,
@@ -517,7 +566,9 @@ func (r *jobRunner) verify(ctx context.Context, logger *slog.Logger,
 	}
 
 	done := make(chan error, 1)
+	ws.bgTasks.Add(1)
 	go func() {
+		defer ws.bgTasks.Done()
 		done <- verify.Run(levelDir, dataDir, cfg)
 	}()
 
@@ -537,23 +588,23 @@ func (r *jobRunner) verify(ctx context.Context, logger *slog.Logger,
 
 // replaceDBTree swaps the original LevelDB subtree in the extracted archive
 // for the newly-produced PebbleDB subtree. When delete_source_snapshot is
-// false, the LevelDB tree is retained alongside the PebbleDB output.
+// false, the LevelDB tree is retained alongside the PebbleDB output under a
+// sibling directory suffixed "_pebbledb".
 func (r *jobRunner) replaceDBTree(levelDir, pebbleDir string) error {
 	dataDir := filepath.Join(pebbleDir, "data")
-	parent := filepath.Dir(levelDir)
-	target := filepath.Join(parent, filepath.Base(levelDir))
+	cleanedLevelDir := filepath.Clean(levelDir)
 
 	if r.deps.Cfg.Conversion.DeleteSourceSnapshot {
-		if err := os.RemoveAll(target); err != nil {
-			return fmt.Errorf("remove source leveldb tree %s: %w", target, err)
+		if err := os.RemoveAll(cleanedLevelDir); err != nil {
+			return fmt.Errorf("remove source leveldb tree %s: %w", cleanedLevelDir, err)
 		}
-		if err := os.Rename(dataDir, target); err != nil {
+		if err := os.Rename(dataDir, cleanedLevelDir); err != nil {
 			return fmt.Errorf("move pebble tree into place: %w", err)
 		}
 		return nil
 	}
-	pebbleTarget := filepath.Join(parent, filepath.Base(levelDir)+"_pebbledb")
-	if err := os.Rename(dataDir, pebbleTarget); err != nil {
+	pebbleSiblingDir := cleanedLevelDir + "_pebbledb"
+	if err := os.Rename(dataDir, pebbleSiblingDir); err != nil {
 		return fmt.Errorf("move pebble tree alongside leveldb: %w", err)
 	}
 	return nil

--- a/internal/daemon/store/scp/scp.go
+++ b/internal/daemon/store/scp/scp.go
@@ -62,10 +62,15 @@ const systemKnownHosts = "/etc/pebblify/known_hosts"
 
 // Sentinel errors returned by the SCP target.
 var (
-	// ErrUnsupportedAuth indicates cfg.AuthentificationMode is unrecognised.
+	// ErrUnsupportedAuth indicates cfg.AuthentificationMode is unrecognised
+	// or not usable by this package.
 	ErrUnsupportedAuth = errors.New("scp: unsupported authentification_mode")
 	// ErrMissingSecret indicates a required secret (key path, password) is empty.
 	ErrMissingSecret = errors.New("scp: missing required secret")
+	// ErrInvalidField indicates a non-secret configuration field (host, port,
+	// username) failed validation. Callers distinguish "bad config" from
+	// "missing secret" by matching on this sentinel via errors.Is.
+	ErrInvalidField = errors.New("scp: invalid field")
 	// ErrKnownHosts indicates the known_hosts file could not be loaded or the
 	// remote host is not present in it.
 	ErrKnownHosts = errors.New("scp: known_hosts validation failed")
@@ -93,13 +98,13 @@ type SCPTarget struct {
 // home). Callers needing a subdirectory encode it in remoteName.
 func New(cfg config.SCPSaveSection, secrets config.Secrets) (*SCPTarget, error) {
 	if cfg.Host == "" {
-		return nil, fmt.Errorf("%w: host must not be empty", ErrMissingSecret)
+		return nil, fmt.Errorf("%w: host must not be empty", ErrInvalidField)
 	}
 	if cfg.Username == "" {
-		return nil, fmt.Errorf("%w: username must not be empty", ErrMissingSecret)
+		return nil, fmt.Errorf("%w: username must not be empty", ErrInvalidField)
 	}
 	if cfg.Port <= 0 || cfg.Port > 65535 {
-		return nil, fmt.Errorf("%w: port %d out of range", ErrMissingSecret, cfg.Port)
+		return nil, fmt.Errorf("%w: port %d out of range", ErrInvalidField, cfg.Port)
 	}
 
 	auth, err := buildAuth(cfg.AuthentificationMode, secrets)
@@ -194,7 +199,14 @@ func buildAuth(mode string, secrets config.Secrets) (ssh.AuthMethod, error) {
 		}
 		return ssh.Password(secrets.SCPPassword), nil
 	case config.SCPAuthNone:
-		return ssh.Password(""), nil
+		// The "none" authentification_mode is reserved for future protocol-level
+		// no-auth support. ssh.Password("") sends an empty-password attempt,
+		// which almost always fails and surfaces as a confusing generic auth
+		// error. Reject the mode at construction so operators receive an
+		// actionable message pointing at authentification_mode instead of
+		// debugging remote sshd logs.
+		return nil, fmt.Errorf("%w: %q mode is not supported; use %q or %q",
+			ErrUnsupportedAuth, mode, config.SCPAuthKey, config.SCPAuthPassword)
 	default:
 		return nil, fmt.Errorf("%w: %q", ErrUnsupportedAuth, mode)
 	}
@@ -253,17 +265,47 @@ func resolveKnownHostsPath() (string, error) {
 		ErrKnownHosts, strings.Join(tried, ", "))
 }
 
-// dialContext wraps ssh.NewClientConn with a context-cancellable TCP dial.
+// dialContext wraps ssh.NewClientConn with a context-cancellable TCP dial and
+// a bounded SSH handshake. Once TCP is up, a deadline is applied to the raw
+// conn so a peer that stalls the SSH key exchange cannot wedge the caller;
+// the deadline is cleared before the handshake value is returned so steady-
+// state reads are not artificially truncated. A watcher goroutine also closes
+// conn on ctx cancellation as a belt-and-suspenders unblock for handshake
+// paths that do not observe the deadline quickly.
 func dialContext(ctx context.Context, network, addr string, cfg *ssh.ClientConfig) (*ssh.Client, error) {
 	var d net.Dialer
 	conn, err := d.DialContext(ctx, network, addr)
 	if err != nil {
 		return nil, err
 	}
+
+	deadline := time.Now().Add(dialTimeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	if err := conn.SetDeadline(deadline); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("set handshake deadline: %w", err)
+	}
+
+	handshakeDone := make(chan struct{})
+	defer close(handshakeDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-handshakeDone:
+		}
+	}()
+
 	c, chans, reqs, err := ssh.NewClientConn(conn, addr, cfg)
 	if err != nil {
 		_ = conn.Close()
 		return nil, err
+	}
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		_ = c.Close()
+		return nil, fmt.Errorf("clear handshake deadline: %w", err)
 	}
 	return ssh.NewClient(c, chans, reqs), nil
 }

--- a/internal/daemon/store/scp/scp_test.go
+++ b/internal/daemon/store/scp/scp_test.go
@@ -140,15 +140,15 @@ func TestReadAck_CancelledContext(t *testing.T) {
 
 // ---- buildAuth ----
 
-// TestBuildAuth_NoneMode returns a non-nil AuthMethod for the "none" auth mode.
+// TestBuildAuth_NoneMode returns ErrUnsupportedAuth for the "none" auth mode.
+// The "none" mode is explicitly rejected because ssh.Password("") sends an
+// empty-password attempt that almost always fails and produces a confusing
+// error. Operators must use "key" or "password" instead.
 func TestBuildAuth_NoneMode(t *testing.T) {
 	t.Parallel()
-	auth, err := buildAuth(config.SCPAuthNone, config.Secrets{})
-	if err != nil {
-		t.Fatalf("buildAuth(none) unexpected error: %v", err)
-	}
-	if auth == nil {
-		t.Error("buildAuth(none) returned nil AuthMethod")
+	_, err := buildAuth(config.SCPAuthNone, config.Secrets{})
+	if !errors.Is(err, ErrUnsupportedAuth) {
+		t.Errorf("buildAuth(none) error = %v, want wrapping %v", err, ErrUnsupportedAuth)
 	}
 }
 
@@ -206,9 +206,10 @@ func TestBuildAuth_UnknownMode(t *testing.T) {
 // recognised branch (none + password + key-with-missing-path before read).
 func TestBuildAuth_AllKnownModesCovered(t *testing.T) {
 	t.Parallel()
-	// none — should succeed
-	if _, err := buildAuth(config.SCPAuthNone, config.Secrets{}); err != nil {
-		t.Errorf("buildAuth(none) unexpected error: %v", err)
+	// none — must return ErrUnsupportedAuth; the mode is reserved but not implemented
+	// because ssh.Password("") sends an empty-password attempt that misleads operators.
+	if _, err := buildAuth(config.SCPAuthNone, config.Secrets{}); !errors.Is(err, ErrUnsupportedAuth) {
+		t.Errorf("buildAuth(none) error = %v, want wrapping %v", err, ErrUnsupportedAuth)
 	}
 	// password with value — should succeed
 	if _, err := buildAuth(config.SCPAuthPassword, config.Secrets{SCPPassword: "x"}); err != nil {

--- a/internal/daemon/telemetry/telemetry_test.go
+++ b/internal/daemon/telemetry/telemetry_test.go
@@ -28,6 +28,18 @@ func scrapeMetrics(t *testing.T, reg *prometheus.Registry) string {
 	return rr.Body.String()
 }
 
+// mustRegister registers each collector with reg and fatally fails the test on any error.
+// Using this helper instead of silently discarding the error from reg.Register ensures
+// test setup failures surface immediately rather than producing silent no-ops.
+func mustRegister(t *testing.T, reg *prometheus.Registry, collectors ...prometheus.Collector) {
+	t.Helper()
+	for _, c := range collectors {
+		if err := reg.Register(c); err != nil {
+			t.Fatalf("mustRegister: failed to register collector: %v", err)
+		}
+	}
+}
+
 // ---- Collectors helper method tests ----
 
 // TestCollectors_RecordEnqueue_IncrementsEnqueuedAndSetsDepth.
@@ -42,8 +54,7 @@ func TestCollectors_RecordEnqueue_IncrementsEnqueuedAndSetsDepth(t *testing.T) {
 			Namespace: "t", Name: "queue_depth", Help: "h",
 		}),
 	}
-	_ = reg.Register(c.JobsTotal)
-	_ = reg.Register(c.QueueDepth)
+	mustRegister(t, reg, c.JobsTotal, c.QueueDepth)
 
 	c.RecordEnqueue(5)
 
@@ -65,7 +76,7 @@ func TestCollectors_RecordDequeue_UpdatesQueueDepth(t *testing.T) {
 			Namespace: "t", Name: "queue_depth_d", Help: "h",
 		}),
 	}
-	_ = reg.Register(c.QueueDepth)
+	mustRegister(t, reg, c.QueueDepth)
 
 	c.RecordDequeue(3)
 	body := scrapeMetrics(t, reg)
@@ -83,7 +94,7 @@ func TestCollectors_RecordJobStart_SetsActiveToOne(t *testing.T) {
 			Namespace: "t", Name: "active_s", Help: "h",
 		}),
 	}
-	_ = reg.Register(c.Active)
+	mustRegister(t, reg, c.Active)
 	c.RecordJobStart()
 	body := scrapeMetrics(t, reg)
 	if !strings.Contains(body, "1") {
@@ -106,9 +117,7 @@ func TestCollectors_RecordJobEnd_Success_SetsCompletedAndClearsActive(t *testing
 			Namespace: "t", Name: "active_end", Help: "h",
 		}),
 	}
-	_ = reg.Register(c.JobsTotal)
-	_ = reg.Register(c.JobDuration)
-	_ = reg.Register(c.Active)
+	mustRegister(t, reg, c.JobsTotal, c.JobDuration, c.Active)
 
 	c.Active.Set(1)
 	c.RecordJobEnd(500*time.Millisecond, true)
@@ -138,9 +147,7 @@ func TestCollectors_RecordJobEnd_Failure_SetsFailedLabel(t *testing.T) {
 			Namespace: "t", Name: "active_fail", Help: "h",
 		}),
 	}
-	_ = reg.Register(c.JobsTotal)
-	_ = reg.Register(c.JobDuration)
-	_ = reg.Register(c.Active)
+	mustRegister(t, reg, c.JobsTotal, c.JobDuration, c.Active)
 
 	c.RecordJobEnd(time.Second, false)
 
@@ -159,7 +166,7 @@ func TestCollectors_AddBytesDownloaded_Accumulates(t *testing.T) {
 			Namespace: "t", Name: "bytes_dl", Help: "h",
 		}),
 	}
-	_ = reg.Register(c.BytesDownloaded)
+	mustRegister(t, reg, c.BytesDownloaded)
 
 	c.AddBytesDownloaded(1024)
 	c.AddBytesDownloaded(1024)
@@ -179,7 +186,7 @@ func TestCollectors_AddBytesUploaded_Accumulates(t *testing.T) {
 			Namespace: "t", Name: "bytes_ul", Help: "h",
 		}),
 	}
-	_ = reg.Register(c.BytesUploaded)
+	mustRegister(t, reg, c.BytesUploaded)
 
 	c.AddBytesUploaded(512)
 	c.AddBytesUploaded(512)
@@ -215,7 +222,7 @@ func TestCollectors_AddBytesDownloaded_ZeroAndNegativeSkipped(t *testing.T) {
 			Namespace: "t", Name: "bytes_dl_zero", Help: "h",
 		}),
 	}
-	_ = reg.Register(c.BytesDownloaded)
+	mustRegister(t, reg, c.BytesDownloaded)
 
 	c.AddBytesDownloaded(0)
 	c.AddBytesDownloaded(-100)


### PR DESCRIPTION
Final polish ahead of v0.4.0 tag.

config:
- Remove CompressionZip constant + allow-list entry. repack emits only tar-based archives; zip was never a valid output format. Back to {none,lz4,zstd,gzip}.
- validate: use `>` (not `!=`) against SupportedConfigVersion so older configs still work; only newer-than-max rejected.

queue:
- Dequeue-after-Shutdown discard: Dequeue now re-checks q.closed under mutex after the handoff counter increments. If closed, the received job is discarded + ErrShuttingDown returned; pending entry cleaned up. Prevents "promoted job to current after Shutdown drained" race.

runner:
- replaceDBTree simplified to operate on filepath.Clean(levelDir) directly; removed redundant parent/base construction that risked silent misplacement.
- cleanupWorkspace waits (bounded 30s) for leaked convert/verify goroutines via sync.WaitGroup before os.RemoveAll. Fixes deferred-cleanup race introduced by round-2 ctx-wrap.

store/scp:
- dialContext: SSH handshake now bounded by net.Conn deadline
  + ctx-watcher goroutine closes the underlying conn on cancellation. Peer stalling key exchange can no longer hang the daemon forever.
- Validation wraps ErrInvalidField (new sentinel) for host, username, port — distinct from ErrMissingSecret which means env var absent.
- SCPAuthNone rejected at target construction with ErrUnsupportedAuth. Config validation still allows the value (so disabled SCP with mode=none parses) but an enabled SCP store with mode=none now fails loudly at factory time.

Tests:
- scp_test: isolate known_hosts lookup via env vars (PEBBLIFY_SCP_KNOWN_HOSTS to t.TempDir, HOME to t.TempDir) so system paths like /etc/pebblify/known_hosts never participate.
- telemetry_test: replace MustRegister with Register + t.Fatalf error handling; no more test-panic on duplicate metric.
- scp_test: TestBuildAuth_NoneMode + TestBuildAuth_AllKnownModes updated to assert ErrUnsupportedAuth for none mode.
- queue_test: coverage of Dequeue discarding received jobs when queue closed mid-receive.

Checks:
- go test ./... -race -timeout 180s -> all PASS
- golangci-lint run ./... -> 0 issues
- 4-target cross-compile -> PASS

Part of #49 (round 3)