### PR TITLE
fix(ci,container): GHCR package page — semver tag first + description inheritance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
           labels: |
             org.opencontainers.image.title=Pebblify
             org.opencontainers.image.description=LevelDB to PebbleDB migration tool for Cosmos/CometBFT nodes.
@@ -152,6 +153,13 @@ jobs:
           subject-name: ghcr.io/${{ steps.repo.outputs.name }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      - name: Re-tag latest after attestation (surface semver first in GHCR UI)
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ steps.repo.outputs.name }}:latest \
+            ghcr.io/${{ steps.repo.outputs.name }}@${{ steps.push.outputs.digest }}
 
   release:
     name: GitHub Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ LABEL org.opencontainers.image.title="Pebblify" \
       org.opencontainers.image.description="LevelDB to PebbleDB migration tool and long-running daemon for Cosmos/CometBFT nodes (CLI + daemon modes)." \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.revision="${REVISION}" \
-      org.opencontainers.image.source="https://github.com/Dockermint/Pebblify" \
       org.opencontainers.image.url="https://www.dockermint.io" \
       org.opencontainers.image.documentation="https://docs.dockermint.io/pebblify/" \
       org.opencontainers.image.licenses="Apache-2.0" \


### PR DESCRIPTION
## Description

Fix GHCR package page UX to surface semver/latest tags first in the tag list (not the attestation digest) and restore description inheritance from the repository.

Spec: `docs/specs/ghcr-package-display-fix.md` (CEO-approved 2026-04-22)

## Type of change

- [x] ci / fix (container)

## Changes

- `.github/workflows/release.yml`: 
  - Add `type=raw,value=latest` tag in docker/metadata-action with pre-release guard (`enable=${{ !contains(github.ref_name, '-') }}`)
  - New step after Attest Docker image provenance: `docker buildx imagetools create` re-tags `latest` at the pushed digest (tag-pointer-only, no rebuild), same guard applied
  
- `Dockerfile`:
  - Remove hardcoded `org.opencontainers.image.source` LABEL (was `github.com/Dockermint/Pebblify` with capital P)
  - Allows docker/metadata-action to inject lowercase `github.com/dockermint/pebblify` as sole source of truth
  - LABEL count: 12 → 11

## Testing

- [x] Podman build passes locally with Dockerfile change; all 4 build targets (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64) validated via CI
- [x] Full release path will be validated via `v0.4.1-rc1` canary tag per CEO decision D4
- [x] Pre-merge gates satisfied: @reviewer APPROVE; @qa N/A (no Go); @lead-dev N/A (no deps/modularity); CTO pre-push PASS

## Breaking changes

None.

## Out of Scope Changes

**Manual one-time CEO action required post-merge:**
- In GHCR package settings for `pebblify`, manually select "Inherit access from repository"
- This restores description inheritance from the dockermint/pebblify GitHub repo
- Documented as post-merge step; will be added to `docs/markdown/release-automation.md` in follow-up technical-writer pass

**Floating 'latest' tag:**
- `latest` tag now floats across releases (points to most recent semver)
- Pinning recommendation already documented in README; no change needed

## Validation plan post-merge

1. CEO cuts `v0.4.1-rc1` tag → confirm workflow runs, **does NOT tag 'latest'** (pre-release guard active)
2. Confirm `gh attestation verify oci://ghcr.io/dockermint/pebblify:0.4.1-rc1` succeeds
3. If rc1 green, CEO cuts `v0.4.1` tag
4. Confirm GHCR UI shows `latest` / `0.4.1` / `0.4` in tag list first (not attestation digest), description visible, Repository link resolves to dockermint/pebblify

## Related

- Closes #66
- Part of v0.4.1 consolidation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined Docker image tagging strategy to apply `:latest` tag selectively for stable releases.
  * Updated container image metadata labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->