### PR TITLE
release: v0.4.1 consolidation — CI fix re-promotion — consolidates #70

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
     permissions:
       id-token: write
       attestations: write
+      artifact-metadata: write
       contents: read
     steps:
       - uses: actions/download-artifact@v8
@@ -67,8 +68,8 @@ jobs:
           pattern: pebblify-*
           merge-multiple: true
 
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+      - name: Attest binary provenance
+        uses: actions/attest@v4
         with:
           subject-path: artifacts/pebblify-*
 
@@ -79,8 +80,8 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
 
-      - name: Attest SBOM
-        uses: actions/attest-sbom@v4
+      - name: Attest binary SBOM
+        uses: actions/attest@v4
         with:
           subject-path: artifacts/pebblify-*
           sbom-path: sbom.spdx.json
@@ -91,6 +92,7 @@ jobs:
     permissions:
       packages: write
       attestations: write
+      artifact-metadata: write
       id-token: write
       contents: read
     steps:
@@ -148,7 +150,7 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
 
       - name: Attest Docker image provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-name: ghcr.io/${{ steps.repo.outputs.name }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
## Release v0.4.1 consolidation — CI fix re-promotion

Re-promotes the CI attestation migration into `main` after v0.4.1-rc1 pipeline failure. No user-facing change vs PR #69; only the release workflow was fixed.

## Consolidated issues

- #70 — fix(ci): migrate attest actions + add artifact-metadata permission (merged via PR #71)

## Summary of changes vs main

- `.github/workflows/release.yml` — 3× `actions/attest@v4` (was 2× attest-build-provenance + 1× attest-sbom); 2× new `artifact-metadata: write` permission.

## Release sequence (CEO manual)

1. Merge this PR.
2. Delete stale `v0.4.1-rc1` tag (local + remote) — points at broken pipeline.
3. Cut `v0.4.1-rc2` on new main HEAD; validate pipeline green.
4. If rc2 clean, cut `v0.4.1` final.
5. Manual one-time: GHCR package settings → "Inherit access from repository".

## Out of Scope

- No binary / API / docs changes. Only the release workflow was affected.
- 54 `v0.4.0` → `v0.4.1` doc reference bumps still deferred to step-18 follow-up PR.

Closes #72
