### PR TITLE
fix(docker): bump tzdata Alpine pin from 2026a-r0 to 2026b-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG REVISION=unknown
 # Automated bumps deferred to v0.5.x (Renovate config).
 RUN apk add --no-cache \
         ca-certificates=20260413-r0 \
-        tzdata=2026a-r0
+        tzdata=2026b-r0
 
 WORKDIR /build
 
@@ -54,7 +54,7 @@ LABEL org.opencontainers.image.title="Pebblify" \
 # Automated bumps deferred to v0.5.x (Renovate config).
 RUN apk add --no-cache \
         ca-certificates=20260413-r0 \
-        tzdata=2026a-r0 \
+        tzdata=2026b-r0 \
         wget=1.25.0-r1 \
     && addgroup -g 10000 pebblify \
     && adduser -D -H -u 10000 -G pebblify -s /sbin/nologin pebblify


### PR DESCRIPTION
## Description

Bump Alpine tzdata dependency from 2026a-r0 to 2026b-r0 in Dockerfile. This fixes timezone database expiry issue reported in issue #84, ensuring correctness of time-based operations in containerized migrations.

Spec: N/A (container dependency pin)

## Type of change

- [x] fix

## Changes

- Dockerfile: tzdata pin 2026a-r0 → 2026b-r0

## Testing

- [x] Dockerfile builds without error
- [x] hadolint passes
- [x] Manual image inspection confirms tzdata version in final layer

## Step 14 Hypothesis Check

**Root assumption:** Alpine 2026b-r0 tzdata is available on Docker Hub for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 at build time and provides correct timezone data beyond April 2026 expiry window.

**Pre-merge validation:** Dockerfile syntax valid (hadolint clean), build matrix passes for all target architectures. Multi-arch build attestation succeeds.

**Post-merge validation plan:**
- [ ] Release build completes for all architectures (linux/amd64, linux/arm64)
- [ ] Container startup test: verify tzdata is installed + correct version in final image
- [ ] Timezone API sanity check: test call to `time.Now()` + timezone lookup for dates post-April 2026 in smoke test
- [ ] Confirm no timezone-related errors in logs during container runtime (if applicable)

**Rollback contingency:** If 2026b-r0 becomes unavailable or fails on a specific architecture, revert to 2026c-r0 (or latest stable). This pin is backwards-compatible; no data migration or config change required. Simple `git revert` + rebuild.

---

Closes #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated timezone database package.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dockermint/pebblify/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->